### PR TITLE
Update browserlist supported browsers matrix

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,10 +7,12 @@
 					"last 2 Firefox versions",
 					"last 2 Safari versions",
 					"last 2 Edge versions",
+					"last 2 Opera versions"
 					"last 2 iOS versions",
 					"last 1 Android version",
 					"last 1 ChromeAndroid version",
-					"ie 11"
+					"ie 11",
+					"> 1%"
 				]
 			}
 		} ]

--- a/.babelrc
+++ b/.babelrc
@@ -7,7 +7,7 @@
 					"last 2 Firefox versions",
 					"last 2 Safari versions",
 					"last 2 Edge versions",
-					"last 2 Opera versions"
+					"last 2 Opera versions",
 					"last 2 iOS versions",
 					"last 1 Android version",
 					"last 1 ChromeAndroid version",


### PR DESCRIPTION
WordPress supported browsers: https://make.wordpress.org/design/handbook/design-guide/browser-support/