### PR TITLE
Test: Setup unit testing using Jest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 /packages/*/build/
 /packages/*/build-module/
 /packages/*/build-browser/
+
+coverage/

--- a/package.json
+++ b/package.json
@@ -6,12 +6,14 @@
     "babel-preset-env": "^1.5.2",
     "chalk": "^1.1.3",
     "glob": "^7.1.2",
+    "jest": "^20.0.4",
     "lerna": "^2.0.0-rc.5",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.6.1"
   },
   "scripts": {
     "build-clean": "rimraf ./packages/*/build ./packages/*/build-browser ./packages/*/build-module",
-    "build": "node ./scripts/build.js"
+    "build": "node ./scripts/build.js",
+    "test": "jest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build-clean": "rimraf ./packages/*/build ./packages/*/build-browser ./packages/*/build-module",
     "build": "node ./scripts/build.js",
-    "test": "jest"
+    "test": "jest",
+    "watch": "jest --watch"
   }
 }

--- a/packages/url/src/test/index.test.js
+++ b/packages/url/src/test/index.test.js
@@ -1,0 +1,20 @@
+/**
+ * Internal Dependencies
+ */
+import { addQueryArgs } from '../';
+
+describe( 'addQueryArgs', () => {
+	test( 'should append args to an URL without query string', () => {
+		const url = 'https://andalouses.com/beach';
+		const args = { sun: 'true', sand: 'false' };
+
+		expect( addQueryArgs( url, args ) ).toBe( 'https://andalouses.com/beach?sun=true&sand=false' );
+	} );
+
+	test( 'should append args to an URL with query string', () => {
+		const url = 'https://andalouses.com/beach?night=false';
+		const args = { sun: 'true', sand: 'false' };
+
+		expect( addQueryArgs( url, args ) ).toBe( 'https://andalouses.com/beach?night=false&sun=true&sand=false' );
+	} );
+} );


### PR DESCRIPTION
This PR tries to setup unit testing using the `Jest` Framework and could serve as a starting point of the discussion to choose our Test Runner. 

Jest has solid arguments for it: matchers, mocks, snapshots, an AWESOME cli, coverage webpack and babel integration...), easily configurable

We are using mocha and webpack in Gutenberg but we have some issues (running and building target tests is one of them), Jest resolves them.

I kept it simple, just a unique `npm` script running `jest`.

If you want to experience some niceties of the Jest cli, try running  `npm test -- --watch` or `npm test -- --coverage`