### PR TITLE
Use the independent mode for lerna

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,7 @@
 {
-	"lerna": "2.0.0-rc.5",
-	"packages": [
-		"packages/*"
-	]
+  "lerna": "2.0.0",
+  "packages": [
+    "packages/*"
+  ],
+  "version": "independent"
 }


### PR DESCRIPTION
The independent mode allows us to use a different version number for each module. I think that's what we've settled on.

PS: Lerna command line overrides the indentation.