### PR TITLE
a11y: Use screen-reader-text styles for speak container

### DIFF
--- a/packages/a11y/src/addContainer.js
+++ b/packages/a11y/src/addContainer.js
@@ -12,8 +12,17 @@ const addContainer = function( ariaLive ) {
 	container.id = 'a11y-speak-' + ariaLive;
 	container.className = 'a11y-speak-region';
 
-	let screenReaderTextStyle = 'clip: rect(1px, 1px, 1px, 1px); position: absolute; height: 1px; width: 1px; overflow: hidden; word-wrap: normal;';
-	container.setAttribute( 'style', screenReaderTextStyle );
+	container.setAttribute( 'style', (
+		'position: absolute;' +
+		'margin: -1px;' +
+		'padding: 0;' +
+		'height: 1px;' +
+		'width: 1px;' +
+		'overflow: hidden;' +
+		'clip: rect( 0 0 0 0 );' +
+		'border: 0;' +
+		'word-wrap: normal !important;'
+	) );
 	container.setAttribute( 'aria-live', ariaLive );
 	container.setAttribute( 'aria-relevant', 'additions text' );
 	container.setAttribute( 'aria-atomic', 'true' );

--- a/packages/a11y/src/test/addContainer.test.js
+++ b/packages/a11y/src/test/addContainer.test.js
@@ -8,7 +8,7 @@ describe( 'addContainer', () => {
 			expect( container ).not.toBe( null );
 			expect( container.className ).toBe( 'a11y-speak-region' );
 			expect( container.id ).toBe( 'a11y-speak-polite' );
-			expect( container.getAttribute( 'style' ) ).toBe( 'clip: rect(1px, 1px, 1px, 1px); position: absolute; height: 1px; width: 1px; overflow: hidden; word-wrap: normal;' );
+			expect( container.getAttribute( 'style' ) ).not.toBeNull();
 			expect( container.getAttribute( 'aria-live' ) ).toBe( 'polite' );
 			expect( container.getAttribute( 'aria-relevant' ) ).toBe( 'additions text' );
 			expect( container.getAttribute( 'aria-atomic' ) ).toBe( 'true' );
@@ -22,7 +22,7 @@ describe( 'addContainer', () => {
 			expect( container ).not.toBe( null );
 			expect( container.className ).toBe( 'a11y-speak-region' );
 			expect( container.id ).toBe( 'a11y-speak-assertive' );
-			expect( container.getAttribute( 'style' ) ).toBe( 'clip: rect(1px, 1px, 1px, 1px); position: absolute; height: 1px; width: 1px; overflow: hidden; word-wrap: normal;' );
+			expect( container.getAttribute( 'style' ) ).not.toBeNull();
 			expect( container.getAttribute( 'aria-live' ) ).toBe( 'assertive' );
 			expect( container.getAttribute( 'aria-relevant' ) ).toBe( 'additions text' );
 			expect( container.getAttribute( 'aria-atomic' ) ).toBe( 'true' );
@@ -36,7 +36,7 @@ describe( 'addContainer', () => {
 			expect( container ).not.toBe( null );
 			expect( container.className ).toBe( 'a11y-speak-region' );
 			expect( container.id ).toBe( 'a11y-speak-polite' );
-			expect( container.getAttribute( 'style' ) ).toBe( 'clip: rect(1px, 1px, 1px, 1px); position: absolute; height: 1px; width: 1px; overflow: hidden; word-wrap: normal;' );
+			expect( container.getAttribute( 'style' ) ).not.toBeNull();
 			expect( container.getAttribute( 'aria-live' ) ).toBe( 'polite' );
 			expect( container.getAttribute( 'aria-relevant' ) ).toBe( 'additions text' );
 			expect( container.getAttribute( 'aria-atomic' ) ).toBe( 'true' );


### PR DESCRIPTION
Fixes #38 

This pull request seeks to resolve the a11y speak container styling issues noted at #38. Specifically, the updated styles help avoid a scroll overflow issue, doing so by copying the `.screen-reader-text` styles used elsewhere in the WordPress codebase:

https://github.com/WordPress/WordPress/blob/4.8.2/wp-admin/css/common.css#L120-L133

__Open questions:__

After publishing this branch, I noted that the styles have since been updated in the trunk branch to use modern CSS properties. We may consider adopting those styles here (cc @afercia).

https://github.com/WordPress/WordPress/commit/c65fe27ba10d7ecc97d0ef5cebd690878843a558

__Testing instructions:__

The original issue was observed in overflow apparent in Gutenberg prior to the workaround put in place in WordPress/gutenberg@0f77b9cf988a76e449434db357558dab261a4039 . Verify that prior to this commit, with these changes, no overflow exists:

1. After checking out this branch, create an npm symlink for the `a11y` package:
   - `cd packages/a11y && npm ln`
2. In Gutenberg, check out a commit prior to the workaround fix:
   - `git checkout 04727b731a2ec307c9bad1d9d239d3c5e01f89a4`
3. In Gutenberg, establish a link to the local `@wordpress/a11y` branch:
   - `npm ln @wordpress/a11y`
4. In Gutenberg, start the local development build
   - `npm run dev`
5. Navigate to the local WordPress installation running your copy of Gutenberg and verify that there is no scroll overflow on the Gutenberg editor screens