### PR TITLE
Add option to specify namespace validation regex

### DIFF
--- a/packages/hooks/src/createAddHook.js
+++ b/packages/hooks/src/createAddHook.js
@@ -8,7 +8,7 @@ import validateHookName from './validateHookName.js';
  *
  * @return {Function}       Function that adds a new hook.
  */
-function createAddHook( hooks ) {
+function createAddHook( hooks, options ) {
 	/**
 	 * Adds the hook to the appropriate hooks container.
 	 *
@@ -23,7 +23,7 @@ function createAddHook( hooks ) {
 			return;
 		}
 
-		if ( ! validateNamespace( namespace ) ) {
+		if ( ! validateNamespace( namespace, options.validateNamespaceRegex ) ) {
 			return;
 		}
 

--- a/packages/hooks/src/index.js
+++ b/packages/hooks/src/index.js
@@ -6,7 +6,7 @@ import createCurrentHook from './createCurrentHook';
 import createDoingHook from './createDoingHook';
 import createDidHook from './createDidHook';
 
-function createHooks( options ) {
+function createHooks( options = {} ) {
 	const actions = {};
 	const filters = {};
 

--- a/packages/hooks/src/index.js
+++ b/packages/hooks/src/index.js
@@ -6,13 +6,13 @@ import createCurrentHook from './createCurrentHook';
 import createDoingHook from './createDoingHook';
 import createDidHook from './createDidHook';
 
-function createHooks() {
+function createHooks( options ) {
 	const actions = {};
 	const filters = {};
 
 	return {
-		addAction:        createAddHook( actions ),
-		addFilter:        createAddHook( filters ),
+		addAction:        createAddHook( actions, options ),
+		addFilter:        createAddHook( filters, options ),
 		removeAction:     createRemoveHook( actions ),
 		removeFilter:     createRemoveHook( filters ),
 		hasAction:        createHasHook( actions ),

--- a/packages/hooks/src/test/index.test.js
+++ b/packages/hooks/src/test/index.test.js
@@ -598,3 +598,23 @@ test( 'Test `this` context via composition', () => {
 
 } );
 
+// Test custom namespace validation
+
+test('Accepts namespace with custom namespace regex option', () => {
+
+	const hooks = createHooks( { validateNamespaceRegex: /^[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*$/  } );
+
+	hooks.addFilter('a-hook', 'my-plugin/my-custom-block', () => { });
+
+	expect( console.error ).toHaveBeenCalledTimes( 0 );
+	expect( hooks.filters['a-hook'].handlers.length ).toEqual( 1 );
+} );
+
+test('Rejects namespace with custom namespace regex option', () => {
+
+	const hooks = createHooks( { validateNamespaceRegex: /^[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*$/  } );
+
+	hooks.addFilter('a-hook', 'my-plugin', () => { });
+
+	expect( console.error ).toHaveBeenCalledTimes( 1 );
+} );

--- a/packages/hooks/src/validateNamespace.js
+++ b/packages/hooks/src/validateNamespace.js
@@ -1,20 +1,27 @@
 /**
  * Validate a namespace string.
  *
- * @param  {string} namespace The namespace to validate - should take the form
- *                            `vendor/plugin/function`.
+ * @param  {string} namespace The namespace to validate.
+ *
+ * @param {Regex} validation  Namespace validation regex defaults to /^[a-zA-Z][a-zA-Z0-9_.\-]*$/
  *
  * @return {bool}             Whether the namespace is valid.
  */
-function validateNamespace( namespace ) {
 
+const defaultRegex = /^[a-zA-Z][a-zA-Z0-9_.\-]*$/;
+
+function validateNamespace( namespace, validationRegex = defaultRegex ) {
 	if ( 'string' !== typeof namespace || '' === namespace ) {
 		console.error( 'The namespace must be a non-empty string.' );
 		return false;
 	}
 
-	if ( ! /^[a-zA-Z][a-zA-Z0-9_.\-]*$/.test( namespace ) ) {
-		console.error( 'The namespace can only contain numbers, letters, dashes, periods and underscores.' );
+	if ( ! validationRegex.test( namespace ) ) {
+		if(validationRegex.toString() === defaultRegex.toString()) {
+			console.error( 'The namespace can only contain numbers, letters, dashes, periods and underscores.' );
+		} else {
+			console.error( 'The namespace does not match supplied validation regex \'' + validationRegex.toString() + '\'.' );
+		}
 		return false;
 	}
 


### PR DESCRIPTION
Allows hook namespace to match Gutenberg block registrations.

See https://github.com/WordPress/gutenberg/pull/3621