### PR TITLE
tag a11y and hooks at 1.0.1

### DIFF
--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wordpress/a11y",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Collection of JS modules and tools for WordPress development",
   "homepage": "https://github.com/WordPress/packages/tree/master/packages/a11y/README.md",
   "author": "WordPress",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wordpress/hooks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/WordPress/packages.git"


### PR DESCRIPTION
these version bumps were inadvertently left off at the last deploy.