### PR TITLE
Add package: autop

### DIFF
--- a/packages/autop/README.md
+++ b/packages/autop/README.md
@@ -1,0 +1,30 @@
+# @wordpress/autop
+
+JavaScript port of WordPress's automatic paragraph function `autop` and the `removep` reverse behavior.
+
+## Installation
+
+Install the module
+
+```bash
+npm install @wordpress/autop --save
+```
+
+### Usage
+
+Import the desired function(s) from `@wordpress/autop`:
+
+```js
+import { autop, removep } from '@wordpress/autop';
+
+autop( 'my text' );
+// "<p>my text</p>"
+
+removep( '<p>my text</p>' );
+// "my text"
+```
+
+### API Usage
+
+* `autop( text: string ): string`
+* `remove( text: string ): string`

--- a/packages/autop/package-lock.json
+++ b/packages/autop/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@wordpress/autop",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/packages/autop/package.json
+++ b/packages/autop/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@wordpress/autop",
+  "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/WordPress/packages.git"
+  },
+  "description": "WordPress's automatic paragraph functions `autop` and `removep`",
+  "main": "build/index.js",
+  "module": "build-module/index.js",
+  "author": "WordPress",
+  "license": "GPL-2.0+",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/autop/src/index.js
+++ b/packages/autop/src/index.js
@@ -1,0 +1,262 @@
+/**
+ * Replaces two line breaks with a paragraph tag and one line break with a <br>.
+ *
+ * Similar to `wpautop()` in formatting.php.
+ *
+ * @param   {string} text The text input.
+ * @returns {string}      The formatted text.
+ */
+export function autop( text ) {
+	const blocklist = (
+		'table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre' +
+		'|form|map|area|blockquote|address|math|style|p|h[1-6]|hr|fieldset|legend|section' +
+		'|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary'
+	);
+
+	let preserveLinebreaks = false;
+	let preserveBr = false;
+
+	// Normalize line breaks.
+	text = text.replace( /\r\n|\r/g, '\n' );
+
+	// Remove line breaks from <object>.
+	if ( text.indexOf( '<object' ) !== -1 ) {
+		text = text.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
+			return a.replace( /\n+/g, '' );
+		} );
+	}
+
+	// Remove line breaks from tags.
+	text = text.replace( /<[^<>]+>/g, function( a ) {
+		return a.replace( /[\n\t ]+/g, ' ' );
+	} );
+
+	// Preserve line breaks in <pre> and <script> tags.
+	if ( text.indexOf( '<pre' ) !== -1 || text.indexOf( '<script' ) !== -1 ) {
+		preserveLinebreaks = true;
+		text = text.replace( /<(pre|script)[^>]*>[\s\S]*?<\/\1>/g, function( a ) {
+			return a.replace( /\n/g, '<wp-line-break>' );
+		} );
+	}
+
+	if ( text.indexOf( '<figcaption' ) !== -1 ) {
+		text = text.replace( /\s*(<figcaption[^>]*>)/g, '$1' );
+		text = text.replace( /<\/figcaption>\s*/g, '</figcaption>' );
+	}
+
+	// Keep <br> tags inside captions.
+	if ( text.indexOf( '[caption' ) !== -1 ) {
+		preserveBr = true;
+
+		text = text.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
+			a = a.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' );
+
+			a = a.replace( /<[^<>]+>/g, function( b ) {
+				return b.replace( /[\n\t ]+/, ' ' );
+			} );
+
+			return a.replace( /\s*\n\s*/g, '<wp-temp-br />' );
+		} );
+	}
+
+	text = text + '\n\n';
+	text = text.replace( /<br \/>\s*<br \/>/gi, '\n\n' );
+
+	// Pad block tags with two line breaks.
+	text = text.replace( new RegExp( '(<(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '\n\n$1' );
+	text = text.replace( new RegExp( '(</(?:' + blocklist + ')>)', 'gi' ), '$1\n\n' );
+	text = text.replace( /<hr( [^>]*)?>/gi, '<hr$1>\n\n' );
+
+	// Remove white space chars around <option>.
+	text = text.replace( /\s*<option/gi, '<option' );
+	text = text.replace( /<\/option>\s*/gi, '</option>' );
+
+	// Normalize multiple line breaks and white space chars.
+	text = text.replace( /\n\s*\n+/g, '\n\n' );
+
+	// Convert two line breaks to a paragraph.
+	text = text.replace( /([\s\S]+?)\n\n/g, '<p>$1</p>\n' );
+
+	// Remove empty paragraphs.
+	text = text.replace( /<p>\s*?<\/p>/gi, '' );
+
+	// Remove <p> tags that are around block tags.
+	text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
+	text = text.replace( /<p>(<li.+?)<\/p>/gi, '$1' );
+
+	// Fix <p> in blockquotes.
+	text = text.replace( /<p>\s*<blockquote([^>]*)>/gi, '<blockquote$1><p>' );
+	text = text.replace( /<\/blockquote>\s*<\/p>/gi, '</p></blockquote>' );
+
+	// Remove <p> tags that are wrapped around block tags.
+	text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '$1' );
+	text = text.replace( new RegExp( '(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
+
+	text = text.replace( /(<br[^>]*>)\s*\n/gi, '$1' );
+
+	// Add <br> tags.
+	text = text.replace( /\s*\n/g, '<br />\n' );
+
+	// Remove <br> tags that are around block tags.
+	text = text.replace( new RegExp( '(</?(?:' + blocklist + ')[^>]*>)\\s*<br />', 'gi' ), '$1' );
+	text = text.replace( /<br \/>(\s*<\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)/gi, '$1' );
+
+	// Remove <p> and <br> around captions.
+	text = text.replace( /(?:<p>|<br ?\/?>)*\s*\[caption([^\[]+)\[\/caption\]\s*(?:<\/p>|<br ?\/?>)*/gi, '[caption$1[/caption]' );
+
+	// Make sure there is <p> when there is </p> inside block tags that can contain other blocks.
+	text = text.replace( /(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\/p>/g, function( a, b, c ) {
+		if ( c.match( /<p( [^>]*)?>/ ) ) {
+			return a;
+		}
+
+		return b + '<p>' + c + '</p>';
+	} );
+
+	// Restore the line breaks in <pre> and <script> tags.
+	if ( preserveLinebreaks ) {
+		text = text.replace( /<wp-line-break>/g, '\n' );
+	}
+
+	// Restore the <br> tags in captions.
+	if ( preserveBr ) {
+		text = text.replace( /<wp-temp-br([^>]*)>/g, '<br$1>' );
+	}
+
+	return text;
+}
+
+/**
+ * Replaces <p> tags with two line breaks. "Opposite" of wpautop().
+ *
+ * Replaces <p> tags with two line breaks except where the <p> has attributes.
+ * Unifies whitespace.
+ * Indents <li>, <dt> and <dd> for better readability.
+ *
+ * @param  {string} html The content from the editor.
+ * @return {string}      The content with stripped paragraph tags.
+ */
+export function removep( html ) {
+	const blocklist = 'blockquote|ul|ol|li|dl|dt|dd|table|thead|tbody|tfoot|tr|th|td|h[1-6]|fieldset|figure';
+	const blocklist1 = blocklist + '|div|p';
+	const blocklist2 = blocklist + '|pre';
+	const preserve = [];
+	let preserveLinebreaks = false;
+	let preserveBr = false;
+
+	if ( ! html ) {
+		return '';
+	}
+
+	// Protect script and style tags.
+	if ( html.indexOf( '<script' ) !== -1 || html.indexOf( '<style' ) !== -1 ) {
+		html = html.replace( /<(script|style)[^>]*>[\s\S]*?<\/\1>/g, function( match ) {
+			preserve.push( match );
+			return '<wp-preserve>';
+		} );
+	}
+
+	// Protect pre tags.
+	if ( html.indexOf( '<pre' ) !== -1 ) {
+		preserveLinebreaks = true;
+		html = html.replace( /<pre[^>]*>[\s\S]+?<\/pre>/g, function( a ) {
+			a = a.replace( /<br ?\/?>(\r\n|\n)?/g, '<wp-line-break>' );
+			a = a.replace( /<\/?p( [^>]*)?>(\r\n|\n)?/g, '<wp-line-break>' );
+			return a.replace( /\r?\n/g, '<wp-line-break>' );
+		} );
+	}
+
+	// Remove line breaks but keep <br> tags inside image captions.
+	if ( html.indexOf( '[caption' ) !== -1 ) {
+		preserveBr = true;
+		html = html.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
+			return a.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' ).replace( /[\r\n\t]+/, '' );
+		} );
+	}
+
+	// Normalize white space characters before and after block tags.
+	html = html.replace( new RegExp( '\\s*</(' + blocklist1 + ')>\\s*', 'g' ), '</$1>\n' );
+	html = html.replace( new RegExp( '\\s*<((?:' + blocklist1 + ')(?: [^>]*)?)>', 'g' ), '\n<$1>' );
+
+	// Mark </p> if it has any attributes.
+	html = html.replace( /(<p [^>]+>.*?)<\/p>/g, '$1</p#>' );
+
+	// Preserve the first <p> inside a <div>.
+	html = html.replace( /<div( [^>]*)?>\s*<p>/gi, '<div$1>\n\n' );
+
+	// Remove paragraph tags.
+	html = html.replace( /\s*<p>/gi, '' );
+	html = html.replace( /\s*<\/p>\s*/gi, '\n\n' );
+
+	// Normalize white space chars and remove multiple line breaks.
+	html = html.replace( /\n[\s\u00a0]+\n/g, '\n\n' );
+
+	// Replace <br> tags with line breaks.
+	html = html.replace( /(\s*)<br ?\/?>\s*/gi, function( match, space ) {
+		if ( space && space.indexOf( '\n' ) !== -1 ) {
+			return '\n\n';
+		}
+
+		return '\n';
+	} );
+
+	// Fix line breaks around <div>.
+	html = html.replace( /\s*<div/g, '\n<div' );
+	html = html.replace( /<\/div>\s*/g, '</div>\n' );
+
+	// Fix line breaks around caption shortcodes.
+	html = html.replace( /\s*\[caption([^\[]+)\[\/caption\]\s*/gi, '\n\n[caption$1[/caption]\n\n' );
+	html = html.replace( /caption\]\n\n+\[caption/g, 'caption]\n\n[caption' );
+
+	// Pad block elements tags with a line break.
+	html = html.replace( new RegExp( '\\s*<((?:' + blocklist2 + ')(?: [^>]*)?)\\s*>', 'g' ), '\n<$1>' );
+	html = html.replace( new RegExp( '\\s*</(' + blocklist2 + ')>\\s*', 'g' ), '</$1>\n' );
+
+	// Indent <li>, <dt> and <dd> tags.
+	html = html.replace( /<((li|dt|dd)[^>]*)>/g, ' \t<$1>' );
+
+	// Fix line breaks around <select> and <option>.
+	if ( html.indexOf( '<option' ) !== -1 ) {
+		html = html.replace( /\s*<option/g, '\n<option' );
+		html = html.replace( /\s*<\/select>/g, '\n</select>' );
+	}
+
+	// Pad <hr> with two line breaks.
+	if ( html.indexOf( '<hr' ) !== -1 ) {
+		html = html.replace( /\s*<hr( [^>]*)?>\s*/g, '\n\n<hr$1>\n\n' );
+	}
+
+	// Remove line breaks in <object> tags.
+	if ( html.indexOf( '<object' ) !== -1 ) {
+		html = html.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
+			return a.replace( /[\r\n]+/g, '' );
+		} );
+	}
+
+	// Unmark special paragraph closing tags.
+	html = html.replace( /<\/p#>/g, '</p>\n' );
+
+	// Pad remaining <p> tags whit a line break.
+	html = html.replace( /\s*(<p [^>]+>[\s\S]*?<\/p>)/g, '\n$1' );
+
+	// Trim.
+	html = html.replace( /^\s+/, '' );
+	html = html.replace( /[\s\u00a0]+$/, '' );
+
+	if ( preserveLinebreaks ) {
+		html = html.replace( /<wp-line-break>/g, '\n' );
+	}
+
+	if ( preserveBr ) {
+		html = html.replace( /<wp-temp-br([^>]*)>/g, '<br$1>' );
+	}
+
+	// Restore preserved tags.
+	if ( preserve.length ) {
+		html = html.replace( /<wp-preserve>/g, function() {
+			return preserve.shift();
+		} );
+	}
+
+	return html;
+}

--- a/packages/autop/src/test/index.test.js
+++ b/packages/autop/src/test/index.test.js
@@ -91,7 +91,7 @@ test( 'skip input elements', () => {
 	expect( autop( str ).trim() ).toBe( '<p>' + str + '</p>' );
 } );
 
-test.skip( 'source_track_elements', () => {
+test( 'source_track_elements', () => {
 	const content = `Paragraph one.
 
 <video class="wp-video-shortcode" id="video-0-1" width="640" height="360" preload="metadata" controls="controls">
@@ -178,7 +178,7 @@ Paragraph two.`;
 	expect( autop( shortcodeContent ).trim() ).toBe( shortcodeExpected );
 } );
 
-test.skip( 'param embed elements', () => {
+test( 'param embed elements', () => {
 	const content1 = `Paragraph one.
 
 <object width="400" height="224" classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=6,0,40,0">
@@ -256,7 +256,7 @@ test( 'skip select option elements', () => {
 	expect( autop( str ).trim() ).toBe( '<p>' + str + '</p>' );
 } );
 
-test.skip( 'that_autop_treats_block_level_elements_as_blocks', () => {
+test( 'that_autop_treats_block_level_elements_as_blocks', () => {
 	const blocks = [
 		'table',
 		'thead',
@@ -317,7 +317,7 @@ test.skip( 'that_autop_treats_block_level_elements_as_blocks', () => {
 
 	expect( autop( input ).trim() ).toBe( expected );
 
-	input = join( '', $content ); // WS difference
+	input = content.join( '' ); // WS difference
 
 	expect( autop( input ).trim() ).toBe( expected );
 
@@ -398,7 +398,7 @@ test( 'that autop treats inline elements as inline', () => {
 	expect( autop( content ).trim() ).toBe( expected );
 } );
 
-test.skip( 'element sanity', () => {
+test( 'element sanity', () => {
 	[
 		[
 			'Hello <a\nhref="world">',
@@ -443,7 +443,7 @@ test.skip( 'element sanity', () => {
 	} );
 } );
 
-test.skip( 'that autop skips line breaks after br', () => {
+test( 'that autop skips line breaks after br', () => {
 	const content = `
 line 1<br>
 line 2<br/>
@@ -461,7 +461,7 @@ line 5</p>`;
 	expect( autop( content ).trim() ).toBe( expected );
 } );
 
-test.skip( 'that autop adds a paragraph after multiple br', () => {
+test( 'that autop adds a paragraph after multiple br', () => {
 	const content = `
 line 1<br>
 <br/>
@@ -482,7 +482,7 @@ test( 'that text before blocks is peed', () => {
 	expect( autop( content ).trim() ).toBe( expected );
 } );
 
-test.skip( 'that autop doses not add extra closing p in figure', () => {
+test( 'that autop doses not add extra closing p in figure', () => {
 	const content1 = '<figure><img src="example.jpg" /><figcaption>Caption</figcaption></figure>';
 	const expected1 = content1;
 

--- a/packages/autop/src/test/index.test.js
+++ b/packages/autop/src/test/index.test.js
@@ -1,0 +1,499 @@
+/**
+ * Internal dependencies
+ */
+import {
+	autop,
+	removep,
+} from '../';
+
+test( 'empty string', () => {
+	expect( autop( '' ) ).toBe( '' );
+} );
+
+test( 'first post', () => {
+	const expected = `<p>Welcome to WordPress!  This post contains important information.  After you read it, you can make it private to hide it from visitors but still have the information handy for future reference.</p>
+<p>First things first:</p>
+<ul>
+<li><a href="%1$s" title="Subscribe to the WordPress mailing list for Release Notifications">Subscribe to the WordPress mailing list for release notifications</a></li>
+</ul>
+<p>As a subscriber, you will receive an email every time an update is available (and only then).  This will make it easier to keep your site up to date, and secure from evildoers.<br />
+When a new version is released, <a href="%2$s" title="If you are already logged in, this will take you directly to the Dashboard">log in to the Dashboard</a> and follow the instructions.<br />
+Upgrading is a couple of clicks!</p>
+<p>Then you can start enjoying the WordPress experience:</p>
+<ul>
+<li>Edit your personal information at <a href="%3$s" title="Edit settings like your password, your display name and your contact information">Users &#8250; Your Profile</a></li>
+<li>Start publishing at <a href="%4$s" title="Create a new post">Posts &#8250; Add New</a> and at <a href="%5$s" title="Create a new page">Pages &#8250; Add New</a></li>
+<li>Browse and install plugins at <a href="%6$s" title="Browse and install plugins at the official WordPress repository directly from your Dashboard">Plugins &#8250; Add New</a></li>
+<li>Browse and install themes at <a href="%7$s" title="Browse and install themes at the official WordPress repository directly from your Dashboard">Appearance &#8250; Add New Themes</a></li>
+<li>Modify and prettify your website&#8217;s links at <a href="%8$s" title="For example, select a link structure like: http://example.com/1999/12/post-name">Settings &#8250; Permalinks</a></li>
+<li>Import content from another system or WordPress site at <a href="%9$s" title="WordPress comes with importers for the most common publishing systems">Tools &#8250; Import</a></li>
+<li>Find answers to your questions at the <a href="%10$s" title="The official WordPress documentation, maintained by the WordPress community">WordPress Codex</a></li>
+</ul>
+<p>To keep this post for reference, <a href="%11$s" title="Click to edit the content and settings of this post">click to edit it</a>, go to the Publish box and change its Visibility from Public to Private.</p>
+<p>Thank you for selecting WordPress.  We wish you happy publishing!</p>
+<p>PS.  Not yet subscribed for update notifications?  <a href="%1$s" title="Subscribe to the WordPress mailing list for Release Notifications">Do it now!</a></p>
+`;
+	const testData = `Welcome to WordPress!  This post contains important information.  After you read it, you can make it private to hide it from visitors but still have the information handy for future reference.
+
+First things first:
+<ul>
+<li><a href="%1$s" title="Subscribe to the WordPress mailing list for Release Notifications">Subscribe to the WordPress mailing list for release notifications</a></li>
+</ul>
+As a subscriber, you will receive an email every time an update is available (and only then).  This will make it easier to keep your site up to date, and secure from evildoers.
+When a new version is released, <a href="%2$s" title="If you are already logged in, this will take you directly to the Dashboard">log in to the Dashboard</a> and follow the instructions.
+Upgrading is a couple of clicks!
+
+Then you can start enjoying the WordPress experience:
+<ul>
+<li>Edit your personal information at <a href="%3$s" title="Edit settings like your password, your display name and your contact information">Users &#8250; Your Profile</a></li>
+<li>Start publishing at <a href="%4$s" title="Create a new post">Posts &#8250; Add New</a> and at <a href="%5$s" title="Create a new page">Pages &#8250; Add New</a></li>
+<li>Browse and install plugins at <a href="%6$s" title="Browse and install plugins at the official WordPress repository directly from your Dashboard">Plugins &#8250; Add New</a></li>
+<li>Browse and install themes at <a href="%7$s" title="Browse and install themes at the official WordPress repository directly from your Dashboard">Appearance &#8250; Add New Themes</a></li>
+<li>Modify and prettify your website&#8217;s links at <a href="%8$s" title="For example, select a link structure like: http://example.com/1999/12/post-name">Settings &#8250; Permalinks</a></li>
+<li>Import content from another system or WordPress site at <a href="%9$s" title="WordPress comes with importers for the most common publishing systems">Tools &#8250; Import</a></li>
+<li>Find answers to your questions at the <a href="%10$s" title="The official WordPress documentation, maintained by the WordPress community">WordPress Codex</a></li>
+</ul>
+To keep this post for reference, <a href="%11$s" title="Click to edit the content and settings of this post">click to edit it</a>, go to the Publish box and change its Visibility from Public to Private.
+
+Thank you for selecting WordPress.  We wish you happy publishing!
+
+PS.  Not yet subscribed for update notifications?  <a href="%1$s" title="Subscribe to the WordPress mailing list for Release Notifications">Do it now!</a>
+`;
+
+	expect( autop( testData ) ).toBe( expected );
+} );
+
+test( 'skip pre elements', () => {
+	const code = `(function(){
+
+done = 0;
+});`;
+
+	// Not wrapped in <p> tags
+	let str = `<pre>${ code }</pre>`;
+	expect( autop( str ).trim() ).toBe( str );
+
+	// Text before/after is wrapped in <p> tags
+	str = `Look at this code\n\n<pre>${ code }</pre>\n\nIsn't that cool?`;
+
+	// Expected text after autop
+	let expected = '<p>Look at this code</p>\n<pre>' + code + '</pre>\n<p>Isn\'t that cool?</p>';
+	expect( autop( str ).trim() ).toBe( expected );
+
+	// Make sure HTML breaks are maintained if manually inserted
+	str = 'Look at this code\n\n<pre>Line1<br />Line2<br>Line3<br/>Line4\nActual Line 2\nActual Line 3</pre>\n\nCool, huh?';
+	expected = '<p>Look at this code</p>\n<pre>Line1<br />Line2<br>Line3<br/>Line4\nActual Line 2\nActual Line 3</pre>\n<p>Cool, huh?</p>';
+	expect( autop( str ).trim() ).toBe( expected );
+} );
+
+test( 'skip input elements', () => {
+	const str = 'Username: <input type="text" id="username" name="username" /><br />Password: <input type="password" id="password1" name="password1" />';
+	expect( autop( str ).trim() ).toBe( '<p>' + str + '</p>' );
+} );
+
+test.skip( 'source_track_elements', () => {
+	const content = `Paragraph one.
+
+<video class="wp-video-shortcode" id="video-0-1" width="640" height="360" preload="metadata" controls="controls">
+	<source type="video/mp4" src="http://domain.tld/wp-content/uploads/2013/12/xyz.mp4" />
+	<!-- WebM/VP8 for Firefox4, Opera, and Chrome -->
+	<source type="video/webm" src="myvideo.webm" />
+	<!-- Ogg/Vorbis for older Firefox and Opera versions -->
+	<source type="video/ogg" src="myvideo.ogv" />
+	<!-- Optional: Add subtitles for each language -->
+	<track kind="subtitles" src="subtitles.srt" srclang="en" />
+	<!-- Optional: Add chapters -->
+	<track kind="chapters" src="chapters.srt" srclang="en" />
+	<a href="http://domain.tld/wp-content/uploads/2013/12/xyz.mp4">http://domain.tld/wp-content/uploads/2013/12/xyz.mp4</a>
+</video>
+
+Paragraph two.`;
+
+	const content2 = `Paragraph one.
+
+<video class="wp-video-shortcode" id="video-0-1" width="640" height="360" preload="metadata" controls="controls">
+
+<source type="video/mp4" src="http://domain.tld/wp-content/uploads/2013/12/xyz.mp4" />
+
+<!-- WebM/VP8 for Firefox4, Opera, and Chrome -->
+<source type="video/webm" src="myvideo.webm" />
+
+<!-- Ogg/Vorbis for older Firefox and Opera versions -->
+<source type="video/ogg" src="myvideo.ogv" />
+
+<!-- Optional: Add subtitles for each language -->
+<track kind="subtitles" src="subtitles.srt" srclang="en" />
+
+<!-- Optional: Add chapters -->
+<track kind="chapters" src="chapters.srt" srclang="en" />
+
+<a href="http://domain.tld/wp-content/uploads/2013/12/xyz.mp4">http://domain.tld/wp-content/uploads/2013/12/xyz.mp4</a>
+
+</video>
+
+Paragraph two.`;
+
+	const expected = '<p>Paragraph one.</p>\n' + // line breaks only after <p>
+		'<p><video class="wp-video-shortcode" id="video-0-1" width="640" height="360" preload="metadata" controls="controls">' +
+		'<source type="video/mp4" src="http://domain.tld/wp-content/uploads/2013/12/xyz.mp4" />' +
+		'<!-- WebM/VP8 for Firefox4, Opera, and Chrome -->' +
+		'<source type="video/webm" src="myvideo.webm" />' +
+		'<!-- Ogg/Vorbis for older Firefox and Opera versions -->' +
+		'<source type="video/ogg" src="myvideo.ogv" />' +
+		'<!-- Optional: Add subtitles for each language -->' +
+		'<track kind="subtitles" src="subtitles.srt" srclang="en" />' +
+		'<!-- Optional: Add chapters -->' +
+		'<track kind="chapters" src="chapters.srt" srclang="en" />' +
+		'<a href="http://domain.tld/wp-content/uploads/2013/12/xyz.mp4">' +
+		'http://domain.tld/wp-content/uploads/2013/12/xyz.mp4</a></video></p>\n' +
+		'<p>Paragraph two.</p>';
+
+	// When running the content through autop() from wp_richedit_pre()
+	const shortcodeContent = `Paragraph one.
+
+[video width="720" height="480" mp4="http://domain.tld/wp-content/uploads/2013/12/xyz.mp4"]
+<!-- WebM/VP8 for Firefox4, Opera, and Chrome -->
+<source type="video/webm" src="myvideo.webm" />
+<!-- Ogg/Vorbis for older Firefox and Opera versions -->
+<source type="video/ogg" src="myvideo.ogv" />
+<!-- Optional: Add subtitles for each language -->
+<track kind="subtitles" src="subtitles.srt" srclang="en" />
+<!-- Optional: Add chapters -->
+<track kind="chapters" src="chapters.srt" srclang="en" />
+[/video]
+
+Paragraph two.`;
+
+	const shortcodeExpected = '<p>Paragraph one.</p>\n' + // line breaks only after <p>
+		'<p>[video width="720" height="480" mp4="http://domain.tld/wp-content/uploads/2013/12/xyz.mp4"]' +
+		'<!-- WebM/VP8 for Firefox4, Opera, and Chrome --><source type="video/webm" src="myvideo.webm" />' +
+		'<!-- Ogg/Vorbis for older Firefox and Opera versions --><source type="video/ogg" src="myvideo.ogv" />' +
+		'<!-- Optional: Add subtitles for each language --><track kind="subtitles" src="subtitles.srt" srclang="en" />' +
+		'<!-- Optional: Add chapters --><track kind="chapters" src="chapters.srt" srclang="en" />' +
+		'[/video]</p>\n' +
+		'<p>Paragraph two.</p>';
+
+	expect( autop( content ).trim() ).toBe( expected );
+	expect( autop( content2 ).trim() ).toBe( expected );
+	expect( autop( shortcodeContent ).trim() ).toBe( shortcodeExpected );
+} );
+
+test.skip( 'param embed elements', () => {
+	const content1 = `Paragraph one.
+
+<object width="400" height="224" classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=6,0,40,0">
+	<param name="src" value="http://domain.tld/wp-content/uploads/2013/12/xyz.swf" />
+	<param name="allowfullscreen" value="true" />
+	<param name="allowscriptaccess" value="always" />
+	<param name="overstretch" value="true" />
+	<param name="flashvars" value="isDynamicSeeking=true" />
+
+	<embed width="400" height="224" type="application/x-shockwave-flash" src="http://domain.tld/wp-content/uploads/2013/12/xyz.swf" wmode="direct" seamlesstabbing="true" allowfullscreen="true" overstretch="true" flashvars="isDynamicSeeking=true" />
+</object>
+
+Paragraph two.`;
+
+	const expected1 = '<p>Paragraph one.</p>\n' + // line breaks only after <p>
+		'<p><object width="400" height="224" classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=6,0,40,0">' +
+		'<param name="src" value="http://domain.tld/wp-content/uploads/2013/12/xyz.swf" />' +
+		'<param name="allowfullscreen" value="true" />' +
+		'<param name="allowscriptaccess" value="always" />' +
+		'<param name="overstretch" value="true" />' +
+		'<param name="flashvars" value="isDynamicSeeking=true" />' +
+		'<embed width="400" height="224" type="application/x-shockwave-flash" src="http://domain.tld/wp-content/uploads/2013/12/xyz.swf" wmode="direct" seamlesstabbing="true" allowfullscreen="true" overstretch="true" flashvars="isDynamicSeeking=true" />' +
+		'</object></p>\n' +
+		'<p>Paragraph two.</p>';
+
+	const content2 = `Paragraph one.
+
+<div class="video-player" id="x-video-0">
+<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="640" height="360" id="video-0" standby="Standby text">
+<param name="movie" value="http://domain.tld/wp-content/uploads/2013/12/xyz.swf" />
+<param name="quality" value="best" />
+
+<param name="seamlesstabbing" value="true" />
+<param name="allowfullscreen" value="true" />
+<param name="allowscriptaccess" value="always" />
+<param name="overstretch" value="true" />
+
+<!--[if !IE]--><object type="application/x-shockwave-flash" data="http://domain.tld/wp-content/uploads/2013/12/xyz.swf" width="640" height="360" standby="Standby text">
+<param name="quality" value="best" />
+
+<param name="seamlesstabbing" value="true" />
+<param name="allowfullscreen" value="true" />
+<param name="allowscriptaccess" value="always" />
+<param name="overstretch" value="true" />
+</object><!--<![endif]-->
+</object></div>
+
+Paragraph two.`;
+
+	const expected2 = '<p>Paragraph one.</p>\n' + // line breaks only after block tags
+		'<div class="video-player" id="x-video-0">\n' +
+		'<object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="640" height="360" id="video-0" standby="Standby text">' +
+		'<param name="movie" value="http://domain.tld/wp-content/uploads/2013/12/xyz.swf" />' +
+		'<param name="quality" value="best" />' +
+		'<param name="seamlesstabbing" value="true" />' +
+		'<param name="allowfullscreen" value="true" />' +
+		'<param name="allowscriptaccess" value="always" />' +
+		'<param name="overstretch" value="true" />' +
+		'<!--[if !IE]--><object type="application/x-shockwave-flash" data="http://domain.tld/wp-content/uploads/2013/12/xyz.swf" width="640" height="360" standby="Standby text">' +
+		'<param name="quality" value="best" />' +
+		'<param name="seamlesstabbing" value="true" />' +
+		'<param name="allowfullscreen" value="true" />' +
+		'<param name="allowscriptaccess" value="always" />' +
+		'<param name="overstretch" value="true" /></object><!--<![endif]-->' +
+		'</object></div>\n' +
+		'<p>Paragraph two.</p>';
+
+	expect( autop( content1 ).trim() ).toBe( expected1 );
+	expect( autop( content2 ).trim() ).toBe( expected2 );
+} )
+
+test( 'skip select option elements', () => {
+	const str = 'Country: <select id="state" name="state"><option value="1">Alabama</option><option value="2">Alaska</option><option value="3">Arizona</option><option value="4">Arkansas</option><option value="5">California</option></select>';
+
+	expect( autop( str ).trim() ).toBe( '<p>' + str + '</p>' );
+} );
+
+test.skip( 'that_autop_treats_block_level_elements_as_blocks', () => {
+	const blocks = [
+		'table',
+		'thead',
+		'tfoot',
+		'caption',
+		'col',
+		'colgroup',
+		'tbody',
+		'tr',
+		'td',
+		'th',
+		'div',
+		'dl',
+		'dd',
+		'dt',
+		'ul',
+		'ol',
+		'li',
+		'pre',
+		'form',
+		'map',
+		'area',
+		'address',
+		'math',
+		'style',
+		'p',
+		'h1',
+		'h2',
+		'h3',
+		'h4',
+		'h5',
+		'h6',
+		'hr',
+		'fieldset',
+		'legend',
+		'section',
+		'article',
+		'aside',
+		'hgroup',
+		'header',
+		'footer',
+		'nav',
+		'figure',
+		'details',
+		'menu',
+		'summary',
+	];
+
+	// Check whitespace normalization.
+	let content = [];
+
+	blocks.forEach( ( block ) => {
+		content.push( `<${ block }>foo</${ block }>` );
+	} );
+
+	let expected = content.join( '\n' );
+	let input = content.join( '\n\n' ); // WS difference
+
+	expect( autop( input ).trim() ).toBe( expected );
+
+	input = join( '', $content ); // WS difference
+
+	expect( autop( input ).trim() ).toBe( expected );
+
+	// Check whitespace addition.
+	content = [];
+
+	blocks.forEach( ( block ) => {
+		content.push( `<${ block }/>` );
+	} );
+
+	expected = content.join( '\n' );
+	input = content.join( '' );
+
+	expect( autop( input ).trim() ).toBe( expected );
+
+	// Check whitespace addition with attributes.
+	content = [];
+
+	blocks.forEach( ( block ) => {
+		content.push( `<${ block } attr='value'>foo</${ block }>` );
+	} );
+
+	expected = content.join( '\n' );
+	input = content.join( '' );
+
+	expect( autop( input ).trim() ).toBe( expected );
+} );
+
+test( 'autop does not wrap blockquotes but does autop their contents', () => {
+	const content = '<blockquote>foo</blockquote>';
+	const expected = '<blockquote><p>foo</p></blockquote>';
+
+	expect( autop( content ).trim() ).toBe( expected );
+} );
+
+
+test( 'that autop treats inline elements as inline', () => {
+	const inlines = [
+		'a',
+		'em',
+		'strong',
+		'small',
+		's',
+		'cite',
+		'q',
+		'dfn',
+		'abbr',
+		'data',
+		'time',
+		'code',
+		'var',
+		'samp',
+		'kbd',
+		'sub',
+		'sup',
+		'i',
+		'b',
+		'u',
+		'mark',
+		'span',
+		'del',
+		'ins',
+		'noscript',
+		'select',
+	];
+
+	let content = [];
+	let expected = [];
+
+	inlines.forEach( ( inline ) => {
+		content.push( `<${ inline }>foo</${ inline }>` );
+		expected.push( `<p><${ inline }>foo</${ inline }></p>` );
+	} );
+
+	content = content.join( '\n\n' );
+	expected = expected.join( '\n' );
+
+	expect( autop( content ).trim() ).toBe( expected );
+} );
+
+test.skip( 'element sanity', () => {
+	[
+		[
+			'Hello <a\nhref="world">',
+			'<p>Hello <a\nhref="world"></p>\n',
+		],
+		[
+			'Hello <!-- a\nhref="world" -->',
+			'<p>Hello <!-- a\nhref="world" --></p>\n',
+		],
+		[
+			'Hello <!-- <object>\n<param>\n<param>\n<embed>\n</embed>\n</object>\n -->',
+			'<p>Hello <!-- <object>\n<param>\n<param>\n<embed>\n</embed>\n</object>\n --></p>\n',
+		],
+		[
+			'Hello <!-- <object>\n<param/>\n<param/>\n<embed>\n</embed>\n</object>\n -->',
+			'<p>Hello <!-- <object>\n<param/>\n<param/>\n<embed>\n</embed>\n</object>\n --></p>\n',
+		],
+		/* Block elements inside comments will fail this test in all versions, it's not a regression.
+		[
+			'Hello <!-- <hr> a\nhref='world' -->',
+			'<p>Hello <!-- <hr> a\nhref='world' --></p>\n',
+		],
+		[
+			'Hello <![CDATA[ <hr> a\nhttps://youtu.be/jgz0uSaOZbE\n ]]>',
+			'<p>Hello <![CDATA[ <hr> a\nhttps://youtu.be/jgz0uSaOZbE\n ]]></p>\n',
+		],
+		*/
+		[
+			'Hello <![CDATA[ a\nhttps://youtu.be/jgz0uSaOZbE\n ]]>',
+			'<p>Hello <![CDATA[ a\nhttps://youtu.be/jgz0uSaOZbE\n ]]></p>\n',
+		],
+		[
+			'Hello <![CDATA[ <!-- a\nhttps://youtu.be/jgz0uSaOZbE\n a\n9 ]]> -->',
+			'<p>Hello <![CDATA[ <!-- a\nhttps://youtu.be/jgz0uSaOZbE\n a\n9 ]]> --></p>\n',
+		],
+		[
+			'Hello <![CDATA[ <!-- a\nhttps://youtu.be/jgz0uSaOZbE\n a\n9 --> a\n9 ]]>',
+			'<p>Hello <![CDATA[ <!-- a\nhttps://youtu.be/jgz0uSaOZbE\n a\n9 --> a\n9 ]]></p>\n',
+		],
+	].forEach( ( [ input, output ] ) => {
+		expect( autop( input ) ).toBe( output );
+	} );
+} );
+
+test.skip( 'that autop skips line breaks after br', () => {
+	const content = `
+line 1<br>
+line 2<br/>
+line 3<br />
+line 4
+line 5
+`;
+
+	const expected = `<p>line 1<br />
+line 2<br />
+line 3<br />
+line 4<br />
+line 5</p>`;
+
+	expect( autop( content ).trim() ).toBe( expected );
+} );
+
+test.skip( 'that autop adds a paragraph after multiple br', () => {
+	const content = `
+line 1<br>
+<br/>
+line 2<br/>
+<br />
+`;
+
+	const expected = `<p>line 1</p>
+<p>line 2</p>`;
+
+	expect( autop( content ).trim() ).toBe( expected );
+} );
+
+test( 'that text before blocks is peed', () => {
+	const content = 'a<div>b</div>';
+	const expected = '<p>a</p>\n<div>b</div>';
+
+	expect( autop( content ).trim() ).toBe( expected );
+} );
+
+test.skip( 'that autop doses not add extra closing p in figure', () => {
+	const content1 = '<figure><img src="example.jpg" /><figcaption>Caption</figcaption></figure>';
+	const expected1 = content1;
+
+	const content2 = `<figure>
+<img src="example.jpg" />
+<figcaption>Caption</figcaption>
+</figure>`;
+
+	const expected2 = `<figure>
+<img src="example.jpg" /><figcaption>Caption</figcaption></figure>`;
+
+	expect( autop( content1 ).trim() ).toBe( expected1 );
+	expect( autop( content2 ).trim() ).toBe( expected2 );
+} );


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/4005

This pull request seeks to introduce a new `autop` package with two named exports: `autop` and `removep`. Originally these were extracted verbatim from [core's `editor.js`](https://github.com/WordPress/wordpress-develop/blob/53f1c74e1c55910f9b7e4aebc8033571d3e52df8/src/wp-admin/js/editor.js#L890-L1156). However, it was found that the JavaScript implementation of `autop` was lacking in many ways when I sought to port the equivalent PHP tests for `wpautop`. You can see the failing skipped tests in f31289b.

Instead, I _re-_ ported the function directly from the [PHP implementation](https://github.com/WordPress/wordpress-develop/blob/53f1c74e1c55910f9b7e4aebc8033571d3e52df8/src/wp-includes/formatting.php#L438-L608) as faithfully as possible. With the reimplementation in 4846972, all test cases ported from the PHPUnit tests pass.

__Testing instructions:__

Ensure unit tests pass:

```
npm test
```