### PR TITLE
Element Package: Add the Gutenberg Element Module as a reusable package

### DIFF
--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -1,0 +1,65 @@
+# @wordpress/element
+
+Element is, quite simply, an abstraction layer atop [React](https://facebook.github.io/react/).
+
+You may find yourself asking, "Why an abstraction layer?". For a few reasons:
+
+- In many applications, especially those extended by a rich plugin ecosystem as is the case with WordPress, it's wise to create interfaces to underlying third-party code. The thinking is that if ever a need arises to change or even replace the underlying implementation, it can be done without catastrophic rippling effects to dependent code, so long as the interface stays the same.
+- It provides a mechanism to shield implementers by omitting features with uncertain futures (`createClass`, `PropTypes`).
+- It helps avoid incompatibilities between versions by ensuring that every plugin operates on a single centralized version of the code.
+
+
+## Installation
+
+Install the module
+
+```bash
+npm install @wordpress/element@next --save
+```
+
+## Usage
+
+On the `wp.element` global object, you will find the following, ordered roughly be likelihood you'll encounter it in your code:
+
+- [`createElement`](https://facebook.github.io/react/docs/react-api.html#createelement)
+- [`render`](https://facebook.github.io/react/docs/react-dom.html#render)
+
+### Example
+
+Let's render a customized greeting into an empty element:
+
+```html
+<div id="greeting"></div>
+<script>
+function Greeting( props ) {
+	return wp.element.createElement( 'span', null,
+		'Hello ' + props.toWhom + '!'
+	);
+}
+
+wp.element.render(
+	wp.element.createElement( Greeting, { toWhom: 'World' } ),
+	document.getElementById( 'app' )
+);
+</script>
+```
+
+Refer to the [official React Quick Start guide](https://facebook.github.io/react/docs/hello-world.html) for a more thorough walkthrough, in most cases substituting `React` and `ReactDOM` with `wp.element` in code examples.
+
+### JSX
+
+While not at all a requirement to use React, [JSX](https://facebook.github.io/react/docs/introducing-jsx.html) is a recommended syntax extension to compose elements more expressively. Through a build process, JSX is converted back to the `createElement` syntax you see earlier in this document.
+
+If you've configured [Babel](http://babeljs.io/) for your project, you can opt in to JSX syntax by specifying the `pragma` option of the [`transform-react-jsx` plugin](https://www.npmjs.com/package/babel-plugin-transform-react-jsx) in your [`.babelrc` configuration](http://babeljs.io/docs/usage/babelrc/).
+
+```json
+{
+	"plugins": [
+		[ "transform-react-jsx", {
+			"pragma": "wp.element.createElement"
+		} ]
+	]
+}
+```
+
+This config assumes `@wordpress/element` is exposed as `wp.element` global variable.

--- a/packages/element/package-lock.json
+++ b/packages/element/package-lock.json
@@ -1,0 +1,146 @@
+{
+  "name": "@wordpress/element",
+  "version": "1.0.0-beta.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.19"
+      }
+    },
+    "fbjs": {
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "requires": {
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.17"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.3"
+      }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "prop-types": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
+    },
+    "react": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
+      "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0"
+      }
+    },
+    "react-dom": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
+      "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0"
+      }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "ua-parser-js": {
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+    },
+    "whatwg-fetch": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+    }
+  }
+}

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@wordpress/element",
+  "version": "1.0.0-beta.0",
+  "description": "WordPress Element Abstraction.",
+  "author": "WordPress",
+  "license": "GPL-2.0+",
+  "keywords": [
+    "react"
+  ],
+  "homepage": "https://github.com/WordPress/packages/tree/master/packages/element/README.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/WordPress/packages.git"
+  },
+  "bugs": {
+    "url": "https://github.com/WordPress/packages/issues"
+  },
+  "main": "build/index.js",
+  "module": "build-module/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "lodash": "^4.17.4",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
+  }
+}

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -1,0 +1,139 @@
+/**
+ * External dependencies
+ */
+import { createElement, Component, cloneElement, Children } from 'react';
+import { render, findDOMNode, createPortal, unmountComponentAtNode } from 'react-dom';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { camelCase, flowRight, isString, upperFirst } from 'lodash';
+
+/**
+ * Returns a new element of given type. Type can be either a string tag name or
+ * another function which itself returns an element.
+ *
+ * @param  {?(string|Function)} type     Tag name or element creator
+ * @param  {Object}             props    Element properties, either attribute
+ *                                       set to apply to DOM node or values to
+ *                                       pass through to element creator
+ * @param  {...WPElement}       children Descendant elements
+ * @return {WPElement}                   Element
+ */
+export { createElement };
+
+/**
+ * Renders a given element into the target DOM node.
+ *
+ * @param {WPElement} element Element to render
+ * @param {Element}   target  DOM node into which element should be rendered
+ */
+export { render };
+
+/**
+ * Removes any mounted element from the target DOM node.
+ *
+ * @param {Element} target DOM node in which element is to be removed
+ */
+export { unmountComponentAtNode };
+
+/**
+ * A base class to create WordPress Components (Refs, state and lifecycle hooks)
+ */
+export { Component };
+
+/**
+ * Creates a copy of an element with extended props.
+ *
+ * @param  {WPElement} element Element
+ * @param  {?Object}   props   Props to apply to cloned element
+ * @return {WPElement}         Cloned element
+ */
+export { cloneElement };
+
+/**
+ * Finds the dom node of a React component
+ *
+ * @param {Component} component component's instance
+ * @param {Element}   target    DOM node into which element should be rendered
+ */
+export { findDOMNode };
+
+export { Children };
+
+/**
+ * Creates a portal into which a component can be rendered.
+ *
+ * @see https://github.com/facebook/react/issues/10309#issuecomment-318433235
+ *
+ * @param {Component} component Component
+ * @param {Element}   target    DOM node into which element should be rendered
+ */
+export { createPortal };
+
+/**
+ * Renders a given element into a string
+ *
+ * @param  {WPElement} element Element to render
+ * @return {String}            HTML
+ */
+export { renderToStaticMarkup as renderToString };
+
+/**
+ * Concatenate two or more React children objects
+ *
+ * @param  {...?Object} childrenArguments Array of children arguments (array of arrays/strings/objects) to concatenate
+ * @return {Array}                        The concatenated value
+ */
+export function concatChildren( ...childrenArguments ) {
+	return childrenArguments.reduce( ( memo, children, i ) => {
+		Children.forEach( children, ( child, j ) => {
+			if ( child && 'string' !== typeof child ) {
+				child = cloneElement( child, {
+					key: [ i, j ].join(),
+				} );
+			}
+
+			memo.push( child );
+		} );
+
+		return memo;
+	}, [] );
+}
+
+/**
+ * Switches the nodeName of all the elements in the children object
+ *
+ * @param  {?Object} children  Children object
+ * @param  {String}  nodeName  Node name
+ * @return {?Object}           The updated children object
+ */
+export function switchChildrenNodeName( children, nodeName ) {
+	return children && Children.map( children, ( elt, index ) => {
+		if ( isString( elt ) ) {
+			return createElement( nodeName, { key: index }, elt );
+		}
+		const { children: childrenProp, ...props } = elt.props;
+		return createElement( nodeName, { key: index, ...props }, childrenProp );
+	} );
+}
+
+/**
+ * Composes multiple higher-order components into a single higher-order component. Performs right-to-left function
+ * composition, where each successive invocation is supplied the return value of the previous.
+ *
+ * @param {...Function} hocs The HOC functions to invoke.
+ * @return {Function}        Returns the new composite function.
+ */
+export { flowRight as compose };
+
+/**
+ * Returns a wrapped version of a React component's display name.
+ * Higher-order components use getWrapperDisplayName().
+ *
+ * @param {Function|Component} BaseComponent used to detect the existing display name.
+ * @param {String} wrapperName Wrapper name to prepend to the display name.
+ * @return {String}            Wrapped display name.
+ */
+export function getWrapperDisplayName( BaseComponent, wrapperName ) {
+	const { displayName = BaseComponent.name || 'Component' } = BaseComponent;
+
+	return `${ upperFirst( camelCase( wrapperName ) ) }(${ displayName })`;
+}

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { createElement, Component, cloneElement, Children } from 'react';
+import { createElement, Component, cloneElement, Children, Fragment } from 'react';
 import { render, findDOMNode, createPortal, unmountComponentAtNode } from 'react-dom';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { camelCase, flowRight, isString, upperFirst } from 'lodash';
@@ -38,6 +38,11 @@ export { unmountComponentAtNode };
  * A base class to create WordPress Components (Refs, state and lifecycle hooks)
  */
 export { Component };
+
+/**
+ * A component which renders its children without any wrapping element.
+ */
+export { Fragment };
 
 /**
  * Creates a copy of an element with extended props.

--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -99,23 +99,6 @@ export function concatChildren( ...childrenArguments ) {
 }
 
 /**
- * Switches the nodeName of all the elements in the children object
- *
- * @param  {?Object} children  Children object
- * @param  {String}  nodeName  Node name
- * @return {?Object}           The updated children object
- */
-export function switchChildrenNodeName( children, nodeName ) {
-	return children && Children.map( children, ( elt, index ) => {
-		if ( isString( elt ) ) {
-			return createElement( nodeName, { key: index }, elt );
-		}
-		const { children: childrenProp, ...props } = elt.props;
-		return createElement( nodeName, { key: index, ...props }, childrenProp );
-	} );
-}
-
-/**
  * Composes multiple higher-order components into a single higher-order component. Performs right-to-left function
  * composition, where each successive invocation is supplied the return value of the previous.
  *

--- a/packages/element/src/test/index.test.js
+++ b/packages/element/src/test/index.test.js
@@ -6,7 +6,6 @@ import {
 	createElement,
 	concatChildren,
 	renderToString,
-	switchChildrenNodeName,
 	getWrapperDisplayName,
 } from '../';
 
@@ -28,34 +27,6 @@ describe( 'element', () => {
 			expect( concat ).toHaveLength( 2 );
 			expect( concat[ 0 ].key ).toBe( '0,0' );
 			expect( concat[ 1 ].key ).toBe( '1,0' );
-		} );
-	} );
-
-	describe( 'switchChildrenNodeName', () => {
-		it( 'should return undefined for undefined children', () => {
-			expect( switchChildrenNodeName() ).toBeUndefined();
-		} );
-
-		it( 'should switch strings', () => {
-			const children = switchChildrenNodeName( [ 'a', 'b' ], 'strong' );
-			expect( children ).toHaveLength( 2 );
-			expect( children[ 0 ].type ).toBe( 'strong' );
-			expect( children[ 0 ].props.children ).toBe( 'a' );
-			expect( children[ 1 ].type ).toBe( 'strong' );
-			expect( children[ 1 ].props.children ).toBe( 'b' );
-		} );
-
-		it( 'should switch elements', () => {
-			const children = switchChildrenNodeName( [
-				createElement( 'strong', { align: 'left' }, 'Courgette' ),
-				createElement( 'strong', {}, 'Concombre' ),
-			], 'em' );
-			expect( children ).toHaveLength( 2 );
-			expect( children[ 0 ].type ).toBe( 'em' );
-			expect( children[ 0 ].props.children ).toBe( 'Courgette' );
-			expect( children[ 0 ].props.align ).toBe( 'left' );
-			expect( children[ 1 ].type ).toBe( 'em' );
-			expect( children[ 1 ].props.children ).toBe( 'Concombre' );
 		} );
 	} );
 

--- a/packages/element/src/test/index.test.js
+++ b/packages/element/src/test/index.test.js
@@ -1,0 +1,100 @@
+/**
+ * Internal dependencies
+ */
+import {
+	Component,
+	createElement,
+	concatChildren,
+	renderToString,
+	switchChildrenNodeName,
+	getWrapperDisplayName,
+} from '../';
+
+describe( 'element', () => {
+	describe( 'concatChildren', () => {
+		it( 'should return an empty array for undefined children', () => {
+			expect( concatChildren() ).toEqual( [] );
+		} );
+
+		it( 'should concat the string arrays', () => {
+			expect( concatChildren( [ 'a' ], 'b' ) ).toEqual( [ 'a', 'b' ] );
+		} );
+
+		it( 'should concat the object arrays and rewrite keys', () => {
+			const concat = concatChildren(
+				[ createElement( 'strong', {}, 'Courgette' ) ],
+				createElement( 'strong', {}, 'Concombre' )
+			);
+			expect( concat ).toHaveLength( 2 );
+			expect( concat[ 0 ].key ).toBe( '0,0' );
+			expect( concat[ 1 ].key ).toBe( '1,0' );
+		} );
+	} );
+
+	describe( 'switchChildrenNodeName', () => {
+		it( 'should return undefined for undefined children', () => {
+			expect( switchChildrenNodeName() ).toBeUndefined();
+		} );
+
+		it( 'should switch strings', () => {
+			const children = switchChildrenNodeName( [ 'a', 'b' ], 'strong' );
+			expect( children ).toHaveLength( 2 );
+			expect( children[ 0 ].type ).toBe( 'strong' );
+			expect( children[ 0 ].props.children ).toBe( 'a' );
+			expect( children[ 1 ].type ).toBe( 'strong' );
+			expect( children[ 1 ].props.children ).toBe( 'b' );
+		} );
+
+		it( 'should switch elements', () => {
+			const children = switchChildrenNodeName( [
+				createElement( 'strong', { align: 'left' }, 'Courgette' ),
+				createElement( 'strong', {}, 'Concombre' ),
+			], 'em' );
+			expect( children ).toHaveLength( 2 );
+			expect( children[ 0 ].type ).toBe( 'em' );
+			expect( children[ 0 ].props.children ).toBe( 'Courgette' );
+			expect( children[ 0 ].props.align ).toBe( 'left' );
+			expect( children[ 1 ].type ).toBe( 'em' );
+			expect( children[ 1 ].props.children ).toBe( 'Concombre' );
+		} );
+	} );
+
+	describe( 'getWrapperDisplayName()', () => {
+		it( 'should use default name for anonymous function', () => {
+			expect( getWrapperDisplayName( () => createElement( 'div' ), 'test' ) ).toBe( 'Test(Component)' );
+		} );
+
+		it( 'should use camel case starting with upper for wrapper prefix ', () => {
+			expect( getWrapperDisplayName( () => createElement( 'div' ), 'one-two_threeFOUR' ) ).toBe( 'OneTwoThreeFour(Component)' );
+		} );
+
+		it( 'should use function name', () => {
+			function SomeComponent() {
+				return createElement( 'div' );
+			}
+
+			expect( getWrapperDisplayName( SomeComponent, 'test' ) ).toBe( 'Test(SomeComponent)' );
+		} );
+
+		it( 'should use component class name', () => {
+			class SomeComponent extends Component {
+				render() {
+					return createElement( 'div' );
+				}
+			}
+
+			expect( getWrapperDisplayName( SomeComponent, 'test' ) ).toBe( 'Test(SomeComponent)' );
+		} );
+
+		it( 'should use displayName property', () => {
+			class SomeComponent extends Component {
+				render() {
+					return createElement( 'div' );
+				}
+			}
+			SomeComponent.displayName = 'CustomDisplayName';
+
+			expect( getWrapperDisplayName( SomeComponent, 'test' ) ).toBe( 'Test(CustomDisplayName)' );
+		} );
+	} );
+} );


### PR DESCRIPTION
Adds the `element` module extracted as is from "Gutenberg".

If we want to start adding reusable UI components to the packages repository, we need to start by adding the `element` package unless we start using React directly without the abstraction layer.