### PR TITLE
Jest-console: Add new package with console object matchers for Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "coveragePathIgnorePatterns": [
       "<rootDir>/.*/build.*"
     ],
-    "coverageDirectory": "coverage"
+    "coverageDirectory": "coverage",
+    "setupTestFrameworkScriptFile": "./packages/jest-console/build/index.js"
   },
   "scripts": {
     "build-clean": "rimraf ./packages/*/build ./packages/*/build-module",

--- a/packages/hooks/src/test/index.test.js
+++ b/packages/hooks/src/test/index.test.js
@@ -23,7 +23,7 @@ import {
 	didFilter,
 	actions,
 	filters,
-} from '../';
+} from '..';
 
 function filter_a( str ) {
 	return str + 'a';
@@ -64,8 +64,6 @@ function action_c() {
 	window.actionValue += 'c';
 }
 
-const consoleErrorOriginal = console.error;
-
 beforeEach( () => {
 	window.actionValue = '';
 	// Reset state in between tests (clear all callbacks, `didAction` counts,
@@ -76,11 +74,6 @@ beforeEach( () => {
 			delete hooks[ k ];
 		}
 	} );
-	console.error = jest.fn();
-} );
-
-afterEach( () => {
-	console.error = consoleErrorOriginal;
 } );
 
 test( 'hooks can be instantiated', () => {
@@ -118,119 +111,119 @@ test( 'remove a non-existent filter', () => {
 
 test( 'remove an invalid namespace from a filter', () => {
 	expect( removeFilter( 'test.filter', 42 ) ).toBe( undefined );
-	expect( console.error ).toHaveBeenCalledWith(
+	expect( console ).toHaveErroredWith(
 		'The namespace must be a non-empty string.'
 	);
 } );
 
 test( 'cannot add filters with non-string hook names', () => {
 	addFilter( 42, 'my_callback', () => null );
-	expect( console.error ).toHaveBeenCalledWith(
+	expect( console ).toHaveErroredWith(
 		'The hook name must be a non-empty string.'
 	);
 } );
 
 test( 'cannot add filters with empty-string hook names', () => {
 	addFilter( '', 'my_callback', () => null );
-	expect( console.error ).toHaveBeenCalledWith(
+	expect( console ).toHaveErroredWith(
 		'The hook name must be a non-empty string.'
 	);
 } );
 
 test( 'cannot add filters with empty-string namespaces', () => {
 	addFilter( 'hook_name', '', () => null );
-	expect( console.error ).toHaveBeenCalledWith(
+	expect( console ).toHaveErroredWith(
 		'The namespace must be a non-empty string.'
 	);
 } );
 
 test( 'cannot add filters with invalid namespaces', () => {
 	addFilter( 'hook_name', 'invalid_%&name', () => null );
-	expect( console.error ).toHaveBeenCalledWith(
+	expect( console ).toHaveErroredWith(
 		'The namespace can only contain numbers, letters, dashes, periods, underscores and slashes.'
 	);
 } );
 
 test( 'Can add filters with dashes in namespaces', () => {
 	addFilter( 'hook_name', 'with-dashes', () => null );
-	expect( console.error ).toHaveBeenCalledTimes( 0 );
+	expect( console ).not.toHaveErrored();
 } );
 
 test( 'Can add filters with capitals in namespaces', () => {
 	addFilter( 'hook_name', 'My_Name-OhNoaction', () => null );
-	expect( console.error ).toHaveBeenCalledTimes( 0 );
+	expect( console ).not.toHaveErrored();
 } );
 
 test( 'Can add filters with slashes in namespaces', () => {
 	addFilter( 'hook_name', 'my/name/action', () => null );
-	expect( console.error ).toHaveBeenCalledTimes( 0 );
+	expect( console ).not.toHaveErrored();
 } );
 
 test( 'Can add filters with periods in namespaces', () => {
 	addFilter( 'hook_name', 'my.name.action', () => null );
-	expect( console.error ).toHaveBeenCalledTimes( 0 );
+	expect( console ).not.toHaveErrored();
 } );
 
 test( 'Can add filters with capitals in hookName', () => {
 	addFilter( 'hookName', 'action', () => null );
-	expect( console.error ).toHaveBeenCalledTimes( 0 );
+	expect( console ).not.toHaveErrored();
 } );
 
 test( 'Can add filters with periods in namespaces', () => {
 	addFilter( 'hook_name', 'ok.action', () => null );
-	expect( console.error ).toHaveBeenCalledTimes( 0 );
+	expect( console ).not.toHaveErrored();
 } );
 
 test( 'Can add filters with periods in hookName', () => {
 	addFilter( 'hook.name', 'action', () => null );
-	expect( console.error ).toHaveBeenCalledTimes( 0 );
+	expect( console ).not.toHaveErrored();
 } );
 
 test( 'cannot add filters with invalid namespaces', () => {
 	addFilter( 'hook_name', '/invalid_name', () => null );
-	expect( console.error ).toHaveBeenCalledWith(
+	expect( console ).toHaveErroredWith(
 		'The namespace can only contain numbers, letters, dashes, periods, underscores and slashes.'
 	);
 } );
 
 test( 'cannot add filters with namespace containing backslash', () => {
 	addFilter( 'hook_name', 'i\n\v\a\l\i\d\n\a\m\e', () => null );
-	expect( console.error ).toHaveBeenCalledWith(
+	expect( console ).toHaveErroredWith(
 		'The namespace can only contain numbers, letters, dashes, periods, underscores and slashes.'
 	);
 } );
 
 test( 'cannot add filters named with __ prefix', () => {
 	addFilter( '__test', 'my_callback', () => null );
-	expect( console.error ).toHaveBeenCalledWith(
+	expect( console ).toHaveErroredWith(
 		'The hook name cannot begin with `__`.'
 	);
 } );
 
 test( 'cannot add filters with non-function callbacks', () => {
 	addFilter( 'test', 'my_callback', '42' );
-	expect( console.error ).toHaveBeenCalledWith(
+	expect( console ).toHaveErroredWith(
 		'The hook callback must be a function.'
 	);
 } );
 
 test( 'cannot add filters with non-numeric priorities', () => {
 	addFilter( 'test', 'my_callback', () => null, '42' );
-	expect( console.error ).toHaveBeenCalledWith(
+	expect( console ).toHaveErroredWith(
 		'If specified, the hook priority must be a number.'
 	);
 } );
 
 test( 'cannot run filters with non-string names', () => {
 	expect( applyFilters( () => {}, 42 ) ).toBe( undefined );
-	expect( console.error ).toHaveBeenCalledWith(
+	expect( console ).toHaveErroredWith(
 		'The hook name must be a non-empty string.'
 	);
 } );
 
 test( 'cannot run filters named with __ prefix', () => {
 	expect( applyFilters( '__test', 42 ) ).toBe( undefined );
-	expect( console.error ).toHaveBeenCalledWith(
+	expect( console ).toHaveErroredWith(
 		'The hook name cannot begin with `__`.'
 	);
 } );
@@ -335,7 +328,7 @@ test( 'fire action multiple times', () => {
 
 	function func() {
 		expect( true ).toBe( true );
-	};
+	}
 
 	addAction( 'test.action', 'my_callback', func );
 	doAction( 'test.action' );
@@ -577,7 +570,7 @@ test( 'adding and removing filters with recursion', () => {
 	function removeRecurseAndAdd2( val ) {
 		expect( removeFilter( 'remove_and_add', 'my_callback_recurse' ) ).toBe( 1 );
 		val += '-' + applyFilters( 'remove_and_add', '' ) + '-';
-		addFilter( 'remove_and_add', 'my_callback_recurse', 10 );
+		addFilter( 'remove_and_add', 'my_callback_recurse', removeRecurseAndAdd2, 10 );
 		return val + '2';
 	}
 
@@ -614,7 +607,7 @@ test( 'Test `this` context via composition', () => {
 	const theCallback = function() {
 		expect( this.test ).toBe( 'test this' );
 	};
-	addAction( 'test.action', 'my_callback', theCallback.apply( testObject ) );
+	addAction( 'test.action', 'my_callback', theCallback.bind( testObject ) );
 	doAction( 'test.action' );
 
 	const testObject2 = {};

--- a/packages/jest-console/README.md
+++ b/packages/jest-console/README.md
@@ -1,0 +1,15 @@
+# @wordpress/jest-console
+
+Testing Matchers for the [Console](https://developer.mozilla.org/en-US/docs/Web/API/Console) object for JavaScript in WordPress.
+
+## Installation
+
+Install the module
+
+```bash
+npm install @wordpress/jest-console --save-dev
+```
+
+### Usage
+
+TBD...

--- a/packages/jest-console/README.md
+++ b/packages/jest-console/README.md
@@ -1,15 +1,90 @@
 # @wordpress/jest-console
 
-Testing Matchers for the [Console](https://developer.mozilla.org/en-US/docs/Web/API/Console) object for JavaScript in WordPress.
+Custom [Jest](http://facebook.github.io/jest/) matchers for the [Console](https://developer.mozilla.org/en-US/docs/Web/API/Console)
+object to test JavaScript code in WordPress.
+
+This package converts `console.error` and `console.warn` functions into mocks and tracks their calls.
+It also enforces usage of one of the related matchers whenever tested code calls one of the mentioned `console` methods.
+It means that you need to assert with `.toHaveErrored()` or `.toHaveErroredWith( arg1, arg2, ... )` when `console.error`
+gets executed, and `.toHaveWarned()` or `.toHaveWarnedWith( arg1, arg2, ... )` when `console.warn` is called.
+Your test will fail otherwise! This is a conscious design decision which helps to detect deprecation warnings when
+upgrading dependent libraries or smaller errors when refactoring code.
 
 ## Installation
 
-Install the module
+Install the module:
 
 ```bash
 npm install @wordpress/jest-console --save-dev
 ```
 
+### Setup
+
+The simplest setup is to use Jest's `setupTestFrameworkScriptFile` config option:
+
+```js
+"jest": {
+  "setupTestFrameworkScriptFile": "./node_modules/@wordpress/jest-console/build/index.js"
+},
+```
+
+If your project already has a script file which sets up the test framework, you will need the following import statement:
+
+```js
+import '@wordpress/jest-console';
+```
+
 ### Usage
 
-TBD...
+### `.toHaveErrored()`
+
+Use `.toHaveErrored` to ensure that `console.error` function got called.
+
+For example, let's say you have a `drinkAll( flavor )` function that makes you drink all available beverages.
+You might want to check if function calls `console.error` for `'octopus'` instead, because `'octopus'` flavor is really
+weird and why would anything be octopus-flavored? You can do that with this test suite:
+
+```js
+describe( 'drinkAll', () => {
+  test( 'drinks something lemon-flavored', () => {
+    drinkAll( 'lemon' );
+    expect( console ).not.toHaveErrored();
+  } );
+
+  test( 'errors when something is octopus-flavored', () => {
+    drinkAll( 'octopus' );
+    expect( console ).toHaveErrored();
+  } );
+} );
+```
+
+### `.toHaveErroredWith( arg1, arg2, ... )`
+
+Use `.toHaveErroredWith` to ensure that `console.error` function was called with
+specific arguments.
+
+For example, let's say you have a `drinkAll( flavor )` function again makes you drink all available beverages.
+You might want to check if function calls `console.error` with a specific message for `'octopus'` instead, because
+`'octopus'` flavor is really weird and why would anything be octopus-flavored? To make sure this works, you could write:
+
+```js
+describe( 'drinkAll', () => {
+  test( 'errors with message when something is octopus-flavored', () => {
+    drinkAll( 'octopus' );
+    expect( console ).toHaveErrored( 'Should I really drink something that is octopus-flavored?' );
+  } );
+} );
+```
+
+### `.toHaveWarned()`
+
+Use `.toHaveWarned` to ensure that `console.warn` function got called.
+
+Almost identical usage as `.toHaveErrored()`.
+
+### `.toHaveWarnedWith( arg1, arg2, ... )`
+
+Use `.toHaveWarneddWith` to ensure that `console.warn` function was called with
+specific arguments.
+
+Almost identical usage as `.toHaveErroredWith()`.

--- a/packages/jest-console/README.md
+++ b/packages/jest-console/README.md
@@ -38,7 +38,7 @@ import '@wordpress/jest-console';
 
 ### `.toHaveErrored()`
 
-Use `.toHaveErrored` to ensure that `console.error` function got called.
+Use `.toHaveErrored` to ensure that `console.error` function was called.
 
 For example, let's say you have a `drinkAll( flavor )` function that makes you drink all available beverages.
 You might want to check if function calls `console.error` for `'octopus'` instead, because `'octopus'` flavor is really
@@ -71,14 +71,14 @@ You might want to check if function calls `console.error` with a specific messag
 describe( 'drinkAll', () => {
   test( 'errors with message when something is octopus-flavored', () => {
     drinkAll( 'octopus' );
-    expect( console ).toHaveErrored( 'Should I really drink something that is octopus-flavored?' );
+    expect( console ).toHaveErroredWith( 'Should I really drink something that is octopus-flavored?' );
   } );
 } );
 ```
 
 ### `.toHaveWarned()`
 
-Use `.toHaveWarned` to ensure that `console.warn` function got called.
+Use `.toHaveWarned` to ensure that `console.warn` function was called.
 
 Almost identical usage as `.toHaveErrored()`.
 

--- a/packages/jest-console/package-lock.json
+++ b/packages/jest-console/package-lock.json
@@ -1,0 +1,89 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"ansi-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+		},
+		"ansi-styles": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+			"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+			"requires": {
+				"color-convert": "1.9.1"
+			}
+		},
+		"chalk": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+			"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+			"requires": {
+				"ansi-styles": "3.2.0",
+				"escape-string-regexp": "1.0.5",
+				"supports-color": "4.5.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"has-flag": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+		},
+		"jest-get-type": {
+			"version": "22.0.3",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.0.3.tgz",
+			"integrity": "sha512-TaJnc/lnJQ3jwry+NUWkqaJmKrM/Ut3XdK89HfiqdI3DMRLd6Zb4wyKjwuNP37MEQqlNg0YWH4sbBR8D4exjCA=="
+		},
+		"jest-matcher-utils": {
+			"version": "22.0.3",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.0.3.tgz",
+			"integrity": "sha512-FJbKpCR3K7YYE/Pnvy5OrLFgPEswpYWIfVtdwT2NC6pBARbYGX39KF3bTxS9yg2mv0YL2zHe3UbwzFsi9nFpVA==",
+			"requires": {
+				"chalk": "2.3.0",
+				"jest-get-type": "22.0.3",
+				"pretty-format": "22.0.3"
+			}
+		},
+		"lodash": {
+			"version": "4.17.4",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+		},
+		"pretty-format": {
+			"version": "22.0.3",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.0.3.tgz",
+			"integrity": "sha512-qXbDFJ2/Kk3HFIaLdOblbsCKQ09kZu4MKbXB+m/EaqD7PZ/wXe2XcRREmQleMh4wmerxlma6eJTh3nxCXYUmmA==",
+			"requires": {
+				"ansi-regex": "3.0.0",
+				"ansi-styles": "3.2.0"
+			}
+		},
+		"supports-color": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+			"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+			"requires": {
+				"has-flag": "2.0.0"
+			}
+		}
+	}
+}

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@wordpress/jest-console",
+  "version": "1.0.0",
+  "description": "Testing Matchers for the Console object",
+  "author": "WordPress",
+  "license": "GPL-2.0-or-later",
+  "keywords": [
+    "jest",
+    "console"
+  ],
+  "homepage": "https://github.com/WordPress/packages/tree/master/packages/jest-console/README.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/WordPress/packages.git"
+  },
+  "bugs": {
+    "url": "https://github.com/WordPress/packages/issues"
+  },
+  "main": "build/index.js",
+  "module": "build-module/index.js",
+  "dependencies": {
+    "jest-matcher-utils": "22.0.3",
+    "lodash": "4.17.4"
+  },
+  "peerDependencies": {
+    "jest": ">=22.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@wordpress/jest-console",
   "version": "1.0.0",
-  "description": "Testing Matchers for the Console object",
+  "description": "Custom Jest matchers for the Console object",
   "author": "WordPress",
   "license": "GPL-2.0-or-later",
   "keywords": [
     "jest",
+    "matchers",
     "console"
   ],
   "homepage": "https://github.com/WordPress/packages/tree/master/packages/jest-console/README.md",

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -19,12 +19,16 @@
   },
   "main": "build/index.js",
   "module": "build-module/index.js",
+  "files": [
+    "build",
+    "build-module"
+  ],
   "dependencies": {
     "jest-matcher-utils": "22.0.3",
     "lodash": "4.17.4"
   },
   "peerDependencies": {
-    "jest": ">=22.0.0"
+    "jest": ">=22"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-console/src/index.js
+++ b/packages/jest-console/src/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { upperFirst } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import './matchers';
@@ -17,8 +22,9 @@ const setConsoleMethodSpy = methodName => {
 	} );
 
 	afterEach( () => {
-		if ( spy.assertionsNumber === 0 ) {
-			expect( spy ).not.toHaveBeenCalled();
+		if ( spy.assertionsNumber === 0 && spy.mock.calls.length > 0 ) {
+			const matcherName = `toHave${ upperFirst( methodName ) }ed`;
+			expect( console ).not[ matcherName ]();
 		}
 	} );
 };

--- a/packages/jest-console/src/index.js
+++ b/packages/jest-console/src/index.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import './matchers';
+
+/**
+ * Sets spy on the console object's method to make it possible to fail test when method called without assertion.
+ *
+ * @param {String} methodName Name of console method.
+ */
+const setConsoleMethodSpy = methodName => {
+	const spy = jest.spyOn( console, methodName ).mockName( `console.${ methodName }` );
+
+	beforeEach( () => {
+		spy.mockReset();
+		spy.assertionsNumber = 0;
+	} );
+
+	afterEach( () => {
+		if ( spy.assertionsNumber === 0 ) {
+			expect( spy ).not.toHaveBeenCalled();
+		}
+	} );
+};
+
+[ 'error', 'warn' ].forEach( setConsoleMethodSpy );

--- a/packages/jest-console/src/matchers.js
+++ b/packages/jest-console/src/matchers.js
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+import { isEqual, some } from 'lodash';
+
+const createToBeCalledMatcher = ( matcherName, methodName ) =>
+	( received ) => {
+		const spy = received[ methodName ];
+		const calls = spy.mock.calls;
+		const pass = calls.length > 0;
+		const message = pass ?
+			() =>
+				matcherHint( `.not${ matcherName }`, spy.getMockName() ) +
+				'\n\n' +
+				'Expected mock function not to be called but it was called with:\n' +
+				calls.map( printReceived ) :
+			() =>
+				matcherHint( matcherName, spy.getMockName() ) +
+				'\n\n' +
+				'Expected mock function to be called.';
+
+		spy.assertionsNumber += 1;
+
+		return {
+			message,
+			pass,
+		};
+	};
+
+const createToBeCalledWithMatcher = ( matcherName, methodName ) =>
+	( received, ...expected ) => {
+		const spy = received[ methodName ];
+		const calls = spy.mock.calls;
+		const pass = some(
+			calls,
+			objects => isEqual( objects, expected )
+		);
+		const message = pass ?
+			() =>
+				matcherHint( `.not${ matcherName }`, spy.getMockName() ) +
+				'\n\n' +
+				'Expected mock function not to be called with:\n' +
+				printExpected( expected ) :
+			() =>
+				matcherHint( matcherName, spy.getMockName() ) +
+				'\n\n' +
+				'Expected mock function to be called with:\n' +
+				printExpected( expected ) + '\n' +
+				'but it was called with:\n' +
+				calls.map( printReceived );
+
+		spy.assertionsNumber += 1;
+
+		return {
+			message,
+			pass,
+		};
+	};
+
+expect.extend( {
+	toHaveErrored: createToBeCalledMatcher( '.toHaveErrored', 'error' ),
+	toHaveErroredWith: createToBeCalledWithMatcher( '.toHaveErroredWith', 'error' ),
+	toHaveWarned: createToBeCalledMatcher( '.toHaveWarned', 'warn' ),
+	toHaveWarnedWith: createToBeCalledWithMatcher( '.toHaveWarnedWith', 'warn' ),
+} );

--- a/packages/jest-console/src/test/__snapshots__/index.test.js.snap
+++ b/packages/jest-console/src/test/__snapshots__/index.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`jest-console console.error toHaveErrored works when not called 1`] = `
+"[2mexpect([22m[31mjest.fn()[39m[2m).toHaveErrored([22m[32mexpected[39m[2m)[22m
+
+Expected mock function to be called."
+`;
+
+exports[`jest-console console.error toHaveErroredWith works when not called 1`] = `
+"[2mexpect([22m[31mjest.fn()[39m[2m).toHaveErroredWith([22m[32mexpected[39m[2m)[22m
+
+Expected mock function to be called with:
+[32m[\\"This is error!\\"][39m
+but it was called with:
+"
+`;
+
+exports[`jest-console console.error toHaveErroredWith works with many arguments that do not match 1`] = `
+"[2mexpect([22m[31mjest.fn()[39m[2m).toHaveErroredWith([22m[32mexpected[39m[2m)[22m
+
+Expected mock function to be called with:
+[32m[\\"This is error!\\"][39m
+but it was called with:
+[31m[\\"Unknown message.\\"][39m,[31m[\\"This is error!\\", \\"Unknown param.\\"][39m"
+`;
+
+exports[`jest-console console.warn toHaveWarned works when not called 1`] = `
+"[2mexpect([22m[31mjest.fn()[39m[2m).toHaveWarned([22m[32mexpected[39m[2m)[22m
+
+Expected mock function to be called."
+`;
+
+exports[`jest-console console.warn toHaveWarnedWith works when not called 1`] = `
+"[2mexpect([22m[31mjest.fn()[39m[2m).toHaveWarnedWith([22m[32mexpected[39m[2m)[22m
+
+Expected mock function to be called with:
+[32m[\\"This is warning!\\"][39m
+but it was called with:
+"
+`;
+
+exports[`jest-console console.warn toHaveWarnedWith works with arguments that do not match 1`] = `
+"[2mexpect([22m[31mjest.fn()[39m[2m).toHaveWarnedWith([22m[32mexpected[39m[2m)[22m
+
+Expected mock function to be called with:
+[32m[\\"This is warning!\\"][39m
+but it was called with:
+[31m[\\"Unknown message.\\"][39m,[31m[\\"This is warning!\\", \\"Unknown param.\\"][39m"
+`;

--- a/packages/jest-console/src/test/index.test.js
+++ b/packages/jest-console/src/test/index.test.js
@@ -1,0 +1,117 @@
+/**
+ * Internal dependencies
+ */
+import '../';
+
+describe( 'jest-console', () => {
+	describe( 'console.error', () => {
+		const message = 'This is error!';
+
+		test( 'toHaveErrored works', () => {
+			console.error( message );
+
+			expect( console ).toHaveErrored();
+		} );
+
+		test( 'toHaveErrored works when not called', () => {
+			expect( console ).not.toHaveErrored();
+			expect(
+				() => expect( console ).toHaveErrored()
+			).toThrowErrorMatchingSnapshot();
+		} );
+
+		test( 'toHaveErroredWith works with arguments that match', () => {
+			console.error( message );
+
+			expect( console ).toHaveErroredWith( message );
+		} );
+
+		test( 'toHaveErroredWith works when not called', () => {
+			expect( console ).not.toHaveErroredWith( message );
+			expect(
+				() => expect( console ).toHaveErroredWith( message )
+			).toThrowErrorMatchingSnapshot();
+		} );
+
+		test( 'toHaveErroredWith works with many arguments that do not match', () => {
+			console.error( 'Unknown message.' );
+			console.error( message, 'Unknown param.' );
+
+			expect( console ).not.toHaveErroredWith( message );
+			expect(
+				() => expect( console ).toHaveErroredWith( message )
+			).toThrowErrorMatchingSnapshot();
+		} );
+
+		test( 'assertions number gets incremented after every matcher call', () => {
+			const spy = console.error;
+
+			expect( spy.assertionsNumber ).toBe( 0 );
+
+			console.error( message );
+
+			expect( console ).toHaveErrored();
+			expect( spy.assertionsNumber ).toBe( 1 );
+
+			expect( console ).toHaveErroredWith( message );
+			expect( spy.assertionsNumber ).toBe( 2 );
+		} );
+	} );
+
+	describe( 'console.warn', () => {
+		const message = 'This is warning!';
+
+		test( 'toHaveWarned works', () => {
+			console.warn( message );
+
+			expect( console ).toHaveWarned();
+		} );
+
+		test( 'toHaveWarned works when not called', () => {
+			expect( console ).not.toHaveWarned();
+
+			expect(
+				() => expect( console ).toHaveWarned()
+			).toThrowErrorMatchingSnapshot();
+		} );
+
+		test( 'toHaveWarnedWith works with arguments that match', () => {
+			console.warn( message );
+
+			expect( console ).toHaveWarnedWith( message );
+		} );
+
+		test( 'toHaveWarnedWith works when not called', () => {
+			expect( console ).not.toHaveWarnedWith( message );
+
+			expect(
+				() => expect( console ).toHaveWarnedWith( message )
+			).toThrowErrorMatchingSnapshot();
+		} );
+
+		test( 'toHaveWarnedWith works with arguments that do not match', () => {
+			console.warn( 'Unknown message.' );
+			console.warn( message, 'Unknown param.' );
+
+			expect( console ).not.toHaveWarnedWith( message );
+
+			expect(
+				() => expect( console ).toHaveWarnedWith( message )
+			).toThrowErrorMatchingSnapshot();
+		} );
+
+		test( 'assertions number gets incremented after every matcher call', () => {
+			const spy = console.warn;
+
+			expect( spy.assertionsNumber ).toBe( 0 );
+
+			console.warn( message );
+
+			expect( console ).toHaveWarned();
+			expect( spy.assertionsNumber ).toBe( 1 );
+
+			expect( console ).toHaveWarnedWith( message );
+			expect( spy.assertionsNumber ).toBe( 2 );
+		} );
+	} );
+} );

--- a/packages/jest-console/src/test/index.test.js
+++ b/packages/jest-console/src/test/index.test.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import '../';
+import '..';
 
 describe( 'jest-console', () => {
 	describe( 'console.error', () => {


### PR DESCRIPTION
Testing Matchers for the [Console](https://developer.mozilla.org/en-US/docs/Web/API/Console) object for JavaScript in WordPress.

Moved from Gutenberg project and improved a bit:
- related PR: https://github.com/WordPress/gutenberg/pull/4285
- related issue: https://github.com/WordPress/gutenberg/issues/4251

I integrated it also with the packages repository. It helped me to discover two subtle bugs in the tests that cover `hooks` package.
  