### PR TITLE
Enforce using the latest LTS version (8.x) of Node and up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: node_js
 node_js:
   - '8'
-  - '6'
 
 script:
   - npm run test:coverage-ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ You can pick among all the <a href="https://github.com/WordPress/packages/issues
 
 ## Developing
 
-Be sure to have [Node.js](https://nodejs.org/en/) installed first. You should be running a a Node version matching the [current active LTS release](https://github.com/nodejs/Release#release-schedule) or newer. You can check this with `node -v`.
+Be sure to have [Node.js](https://nodejs.org/en/) installed first. You should be running a Node.js version matching the [current active LTS release](https://github.com/nodejs/Release#release-schedule) or newer. You can check this with `node -v`.
 
 Make sure that npm is installed with version >= `5.0.0` using `npm -v`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ You can pick among all the <a href="https://github.com/WordPress/packages/issues
 
 ## Developing
 
-Packages is built for Node 6 and up. You can check this with `node -v`.
+Be sure to have [Node.js](https://nodejs.org/en/) installed first. You should be running a a Node version matching the [current active LTS release](https://github.com/nodejs/Release#release-schedule) or newer. You can check this with `node -v`.
 
 Make sure that npm is installed with version >= `5.0.0` using `npm -v`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1152,6 +1152,58 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
+    "check-node-version": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-3.1.1.tgz",
+      "integrity": "sha512-52fHDe/0pbidY3InI33Beyb/oarySfLANlXxLGBl9lLVrLIW88XWIwu4jGJrQ1imuWzX5ukNGWXUyCgmgVUD8A==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "map-values": "1.0.1",
+        "minimist": "1.2.0",
+        "object-filter": "1.0.2",
+        "object.assign": "4.1.0",
+        "run-parallel": "1.1.6",
+        "semver": "5.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "ci-info": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
@@ -3354,6 +3406,12 @@
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -4904,6 +4962,12 @@
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
+    "map-values": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-values/-/map-values-1.0.1.tgz",
+      "integrity": "sha1-douOecAJvytk/ugG4ip7HEGQyZA=",
+      "dev": true
+    },
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -5141,11 +5205,29 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
+    "object-filter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-filter/-/object-filter-1.0.2.tgz",
+      "integrity": "sha1-rwt5f/6+r4pSxmN87b6IFs/sG8g=",
+      "dev": true
+    },
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "object-keys": "1.0.11"
+      }
     },
     "object.getownpropertydescriptors": {
       "version": "2.0.3",
@@ -5980,6 +6062,12 @@
       "requires": {
         "is-promise": "2.1.0"
       }
+    },
+    "run-parallel": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
+      "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk=",
+      "dev": true
     },
     "rx-lite": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "license": "GPL-2.0-or-later",
+  "engines": {
+    "node": ">=8.0.0",
+    "npm": ">=5.0.0"
+  },
   "devDependencies": {
     "babel-core": "^6.25.0",
     "babel-loader": "^7.1.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-env": "^1.5.2",
     "chalk": "^2.0.1",
+    "check-node-version": "^3.1.1",
     "codecov": "^2.2.0",
     "glob": "^7.1.2",
     "jest": "^22.0.3",
@@ -25,7 +30,7 @@
   "scripts": {
     "build-clean": "rimraf ./packages/*/build ./packages/*/build-module",
     "build": "node ./scripts/build.js",
-    "postinstall": "lerna bootstrap && npm run build",
+    "postinstall": "lerna bootstrap && check-node-version --package && npm run build",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:coverage-ci": "jest --coverage && codecov",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
   },
   "scripts": {
     "build-clean": "rimraf ./packages/*/build ./packages/*/build-module",
+    "prebuild": "check-node-version --package",
     "build": "node ./scripts/build.js",
-    "postinstall": "lerna bootstrap && check-node-version --package && npm run build",
+    "postinstall": "lerna bootstrap && npm run build",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:coverage-ci": "jest --coverage && codecov",


### PR DESCRIPTION
When working on #60 I had some random issues with Travis checks on Node 6. This PR removes support for Node 6 and promotes usage of Node 8.x which is the current active LTS version. I added also an additional check which is executed after `npm install` which ensures that proper versions of Node and npm are installed. This setup matches now what we have in Gutenberg. [Related PR](https://github.com/WordPress/gutenberg/pull/3905).

### Testing

Make sure `npm install` doesn't throw any errors when running Node 8 and npm 5.

Try the same with lower version of Node or npm. You can also temporarily bump versions specified in the `engines` section in `package.json. Make sure error is thrown similar to the following:

```bash
Error: Wanted node version >=9.0.0 (>=9.0.0)
To install node, run `nvm install >=9.0.0` or see https://nodejs.org/
```