### PR TITLE
Hooks: Micro-optimize runHooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	},
 	"devDependencies": {
 		"babel-core": "^6.26.0",
+		"benchmark": "^2.1.4",
 		"chalk": "^2.0.1",
 		"check-node-version": "^3.1.1",
 		"codecov": "^2.2.0",

--- a/packages/hooks/benchmark/index.js
+++ b/packages/hooks/benchmark/index.js
@@ -1,0 +1,18 @@
+const Benchmark = require( 'benchmark' );
+const hooks = require( '../' );
+
+const suite = new Benchmark.Suite;
+
+function myCallback() {}
+
+hooks.addFilter( 'handled', 'myCallback', myCallback );
+
+suite
+	.add( 'handled', () => {
+		hooks.applyFilters( 'handled' );
+	} )
+	.add( 'unhandled', () => {
+		hooks.applyFilters( 'unhandled' );
+	} )
+	.on( 'cycle', ( event ) => console.log( event.target.toString() ) )
+	.run( { async: true } );

--- a/packages/hooks/src/createAddHook.js
+++ b/packages/hooks/src/createAddHook.js
@@ -41,7 +41,7 @@ function createAddHook( hooks ) {
 
 		const handler = { callback, priority, namespace };
 
-		if ( hooks.hasOwnProperty( hookName ) ) {
+		if ( hooks[ hookName ] ) {
 			// Find the correct insert index of the new hook.
 			const handlers = hooks[ hookName ].handlers;
 			let i = 0;

--- a/packages/hooks/src/createDidHook.js
+++ b/packages/hooks/src/createDidHook.js
@@ -22,7 +22,7 @@ function createDidHook( hooks ) {
 			return;
 		}
 
-		return hooks.hasOwnProperty( hookName ) && hooks[ hookName ].runs
+		return hooks[ hookName ] && hooks[ hookName ].runs
 			? hooks[ hookName ].runs
 			: 0;
 	};

--- a/packages/hooks/src/createHasHook.js
+++ b/packages/hooks/src/createHasHook.js
@@ -17,7 +17,7 @@ function createHasHook( hooks ) {
 	 *                            the given hook.
 	 */
 	return function hasHook( hookName ) {
-		return hooks.hasOwnProperty( hookName )
+		return hooks[ hookName ]
 			? hooks[ hookName ].handlers.length
 			: 0;
 	};

--- a/packages/hooks/src/createHooks.js
+++ b/packages/hooks/src/createHooks.js
@@ -12,8 +12,8 @@ import createDidHook from './createDidHook';
  * @return {Object} Object that contains all hooks.
  */
 function createHooks() {
-	const actions = {};
-	const filters = {};
+	const actions = Object.create( null );
+	const filters = Object.create( null );
 
 	return {
 		addAction:        createAddHook( actions ),

--- a/packages/hooks/src/createHooks.js
+++ b/packages/hooks/src/createHooks.js
@@ -14,6 +14,8 @@ import createDidHook from './createDidHook';
 function createHooks() {
 	const actions = Object.create( null );
 	const filters = Object.create( null );
+	actions.__current = [];
+	filters.__current = [];
 
 	return {
 		addAction:        createAddHook( actions ),

--- a/packages/hooks/src/createRemoveHook.js
+++ b/packages/hooks/src/createRemoveHook.js
@@ -32,7 +32,7 @@ function createRemoveHook( hooks, removeAll ) {
 		}
 
 		// Bail if no hooks exist by this name
-		if ( ! hooks.hasOwnProperty( hookName ) ) {
+		if ( ! hooks[ hookName ] ) {
 			return 0;
 		}
 

--- a/packages/hooks/src/createRunHook.js
+++ b/packages/hooks/src/createRunHook.js
@@ -21,16 +21,12 @@ function createRunHook( hooks, returnFirstArg ) {
 	 * @return {*}               Return value of runner, if applicable.
 	 */
 	return function runHooks( hookName, ...args ) {
-		if ( ! hooks[ hookName ] ) {
-			hooks[ hookName ] = {
-				runs: 0,
-				handlers: [],
-			};
+		let handlers;
+		if ( hooks[ hookName ] ) {
+			handlers = hooks[ hookName ].handlers;
 		}
 
-		const handlers = hooks[ hookName ].handlers;
-
-		if ( ! handlers.length ) {
+		if ( ! handlers || ! handlers.length ) {
 			return returnFirstArg
 				? args[ 0 ]
 				: undefined;
@@ -42,6 +38,13 @@ function createRunHook( hooks, returnFirstArg ) {
 		};
 
 		hooks.__current.push( hookInfo );
+
+		if ( ! hooks[ hookName ] ) {
+			hooks[ hookName ] = {
+				runs: 0,
+				handlers: [],
+			};
+		}
 		hooks[ hookName ].runs++;
 
 		while ( hookInfo.currentIndex < handlers.length ) {

--- a/packages/hooks/src/createRunHook.js
+++ b/packages/hooks/src/createRunHook.js
@@ -45,21 +45,16 @@ function createRunHook( hooks, returnFirstArg ) {
 		hooks.__current.push( hookInfo );
 		hooks[ hookName ].runs++;
 
-		let maybeReturnValue = args[ 0 ];
-
 		while ( hookInfo.currentIndex < handlers.length ) {
 			const handler = handlers[ hookInfo.currentIndex ];
-			maybeReturnValue = handler.callback.apply( null, args );
-			if ( returnFirstArg ) {
-				args[ 0 ] = maybeReturnValue;
-			}
+			args[ 0 ] = handler.callback.apply( null, args );
 			hookInfo.currentIndex++;
 		}
 
 		hooks.__current.pop();
 
 		if ( returnFirstArg ) {
-			return maybeReturnValue;
+			return args[ 0 ];
 		}
 	};
 }

--- a/packages/hooks/src/createRunHook.js
+++ b/packages/hooks/src/createRunHook.js
@@ -41,7 +41,6 @@ function createRunHook( hooks, returnFirstArg ) {
 			currentIndex: 0,
 		};
 
-		hooks.__current = hooks.__current || [];
 		hooks.__current.push( hookInfo );
 		hooks[ hookName ].runs++;
 

--- a/packages/hooks/src/createRunHook.js
+++ b/packages/hooks/src/createRunHook.js
@@ -21,11 +21,6 @@ function createRunHook( hooks, returnFirstArg ) {
 	 * @return {*}               Return value of runner, if applicable.
 	 */
 	return function runHooks( hookName, ...args ) {
-
-		if ( ! validateHookName( hookName ) ) {
-			return;
-		}
-
 		if ( ! hooks.hasOwnProperty( hookName ) ) {
 			hooks[ hookName ] = {
 				runs: 0,

--- a/packages/hooks/src/createRunHook.js
+++ b/packages/hooks/src/createRunHook.js
@@ -21,7 +21,7 @@ function createRunHook( hooks, returnFirstArg ) {
 	 * @return {*}               Return value of runner, if applicable.
 	 */
 	return function runHooks( hookName, ...args ) {
-		if ( ! hooks.hasOwnProperty( hookName ) ) {
+		if ( ! hooks[ hookName ] ) {
 			hooks[ hookName ] = {
 				runs: 0,
 				handlers: [],

--- a/packages/hooks/src/test/index.test.js
+++ b/packages/hooks/src/test/index.test.js
@@ -71,6 +71,10 @@ beforeEach( () => {
 	// because the internal functions have references to the original objects.
 	[ actions, filters ].forEach( hooks => {
 		for ( const k in hooks ) {
+			if ( '__current' === k ) {
+				continue;
+			}
+
 			delete hooks[ k ];
 		}
 	} );

--- a/packages/hooks/src/test/index.test.js
+++ b/packages/hooks/src/test/index.test.js
@@ -214,20 +214,6 @@ test( 'cannot add filters with non-numeric priorities', () => {
 	);
 } );
 
-test( 'cannot run filters with non-string names', () => {
-	expect( applyFilters( () => {}, 42 ) ).toBe( undefined );
-	expect( console ).toHaveErroredWith(
-		'The hook name must be a non-empty string.'
-	);
-} );
-
-test( 'cannot run filters named with __ prefix', () => {
-	expect( applyFilters( '__test', 42 ) ).toBe( undefined );
-	expect( console ).toHaveErroredWith(
-		'The hook name cannot begin with `__`.'
-	);
-} );
-
 test( 'add 3 filters with different priorities and run them', () => {
 	addFilter( 'test.filter', 'my_callback_filter_a',  filter_a );
 	addFilter( 'test.filter', 'my_callback_filter_b',  filter_b, 2 );


### PR DESCRIPTION
Foreseeing `runHooks` becoming a hot code path, I took to making a few small micro-optimizations, improving the handled and unhandled hook performance by approximately 42% and 172% respectively on my machine (handled meaning at least one hook handler exists). Standard benchmarking caveats apply (Node V8 engine, machine-specific, benchmarks themselves limited in real-world applicability).

**Before:**

```
handled x 5,839,917 ops/sec ±0.32% (91 runs sampled)
unhandled x 7,967,106 ops/sec ±0.63% (89 runs sampled)
```

**After:**

```
handled x 8,306,775 ops/sec ±0.46% (92 runs sampled)
unhandled x 22,606,859 ops/sec ±0.65% (90 runs sampled)
```

Optimizations include:

- Removing unnecessary code (a0e6eb6)
   - Technically, this removal would allow for `doAction( '__current' )` to attempt to find handlers for the internal property, though would fail after the second condition, since array would not have `.handlers` property. To me, it's more concerning that we're allowing for this special key to exist with special treatment in the same scope as other hook handlers.
- Avoid assignment when either unnecessary or redundant (71bd540, 9177da1)
- Performant alternatives (truthy property access on null-prototype object vs. `hasOwnProperty`, faa0ed3, [jsperf](https://jsperf.com/object-create-null-vs-hasownproperty))
   - The reason for `Object.create( null )` is to avoid issues with prototype property access:
      - `!! ( {} ).valueOf // true`
      - `!! Object.create( null ).valueOf // false`

Try yourself:

```
npm install
npm run build
node packages/hooks/benchmark
```