### PR TITLE
Hooks: Fix undefined first argument on consecutive action callbacks

### DIFF
--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -1,0 +1,3 @@
+**1.1.5 (2018-03-21)**
+
+- Fix: Resolves issue where action argument would be undefined on all but the first action callback.

--- a/packages/hooks/src/createRunHook.js
+++ b/packages/hooks/src/createRunHook.js
@@ -49,7 +49,12 @@ function createRunHook( hooks, returnFirstArg ) {
 
 		while ( hookInfo.currentIndex < handlers.length ) {
 			const handler = handlers[ hookInfo.currentIndex ];
-			args[ 0 ] = handler.callback.apply( null, args );
+
+			const result = handler.callback.apply( null, args );
+			if ( returnFirstArg ) {
+				args[ 0 ] = result;
+			}
+
 			hookInfo.currentIndex++;
 		}
 

--- a/packages/hooks/src/test/index.test.js
+++ b/packages/hooks/src/test/index.test.js
@@ -572,6 +572,32 @@ test( 'adding and removing filters with recursion', () => {
 	expect( applyFilters( 'remove_and_add', '' ) ).toBe( '1-134-234' );
 } );
 
+test( 'actions preserve arguments across handlers without return value', () => {
+	const arg1 = { a: 10 };
+	const arg2 = { b: 20 };
+
+	addAction( 'test.action', 'my_callback1', ( a, b ) => {
+		expect( a ).toBe( arg1 );
+		expect( b ).toBe( arg2 );
+	} );
+
+	addAction( 'test.action', 'my_callback2', ( a, b ) => {
+		expect( a ).toBe( arg1 );
+		expect( b ).toBe( arg2 );
+	} );
+
+	doAction( 'test.action', arg1, arg2 );
+} );
+
+test( 'filters pass first argument across handlers', () => {
+	addFilter( 'test.filter', 'my_callback1', ( count ) => count + 1 );
+	addFilter( 'test.filter', 'my_callback2', ( count ) => count + 1 );
+
+	const result = applyFilters( 'test.filter', 0 );
+
+	expect( result ).toBe( 2 );
+} );
+
 // Test adding via composition.
 test( 'adding hooks via composition', () => {
 	const testObject = {};


### PR DESCRIPTION
Regression introduced in #85
Related: https://github.com/WordPress/gutenberg/pull/5588

This pull request seeks to resolve an issue where all but the first action callbacks will receive `undefined` first argument. This is caused by an intended simplification of the first argument assignment in the `createRunHook.js` file. However, this treated actions as the same as filters, thus because most actions do not define a return value, the argument would become unset.

__Testing instructions:__

Verify unit tests pass:

```
npm test
```