### PR TITLE
chore: add` jest-preset` keyword to `jest-preset-default` package

### DIFF
--- a/packages/jest-preset-default/package.json
+++ b/packages/jest-preset-default/package.json
@@ -7,6 +7,7 @@
 	"keywords": [
 		"wordpress",
 		"jest",
+		"jest-preset",
 		"preset",
 		"react",
 		"enzyme"


### PR DESCRIPTION
This PR adds the `jest-preset` keyword to aid discoverability of "Jest Preset" packages on npmjs.com https://www.npmjs.com/browse/keyword/jest-preset