### PR TITLE
Add `publish:check` script to run `lerna updated`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"test:coverage": "npm run test -- --coverage",
 		"test:coverage-ci": "npm run test -- --coverage && codecov",
 		"test:watch": "npm run test -- --watch",
+		"publish:check": "npm run build && lerna updated",
 		"publish:dev": "npm run build && lerna publish --npm-tag next",
 		"publish:prod": "npm run build && lerna publish"
 	}


### PR DESCRIPTION
This PR adds a new npm script `publish:check`, by running `npm run publish:check` Lerna will check which packages have changed (via `lerna updated`) since the last publish (via `lerna publish`).

The script also runs the _build_ scripts for additional pre-release checks
```shell
npm run publish:check
lerna info version 2.9.0
lerna info versioning independent
lerna info ignore [ '**/test/*.js' ]
lerna info Checking for updated packages...
lerna info Comparing with @wordpress/a11y@1.0.7.
lerna info Checking for prereleased packages...
lerna info result 
- @wordpress/jest-preset-default
- @wordpress/scripts
```

Note: The script also runs the _build_ scripts for additional pre-release checks though this isn't displayed in the above example output.