### PR TITLE
Initial `@wordpress/licenses` package

### DIFF
--- a/packages/licenses/.npmrc
+++ b/packages/licenses/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/licenses/CHANGELOG.md
+++ b/packages/licenses/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0 (2018-05-18)
+
+- Initial release `@wordpress/licenses` ([#131](https://github.com/WordPress/packages/pull/131))

--- a/packages/licenses/README.md
+++ b/packages/licenses/README.md
@@ -1,0 +1,31 @@
+# @wordpress/licenses
+
+> WordPress Licenses.
+
+## Installation
+
+Install the module
+
+```shell
+$ npm install @wordpress/licenses
+```
+
+## Usage
+
+```
+const gpl2Licenses = require('@wordpress/licenses/gpl2Licenses');
+//=> [ 'BSD-3-Clause', 'CC-BY-4.0', 'GPL-2.0-or-later', 'MIT', 'Public Domain', ...]
+```
+	
+
+```
+const gpl2Licenses = require('@wordpress/licenses/ossLicenses');
+//=> [ 'Apache-2.0', ]
+```
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>
+
+
+Further research:
+https://github.com/sindresorhus/spdx-license-list
+https://github.com/jslicense/spdx-correct.js/blob/master/index.js < - This package picks up typos

--- a/packages/licenses/gpl2Licenses.js
+++ b/packages/licenses/gpl2Licenses.js
@@ -1,0 +1,16 @@
+module.exports = [
+	'BSD',
+	'BSD-2-Clause',
+	'BSD-3-Clause',
+	'BSD-like',
+	'CC-BY-3.0',
+	'CC-BY-4.0',
+	'CC0-1.0',
+	'GPL-2.0-or-later',
+	'ISC',
+	'MIT',
+	'MIT/X11',
+	'Public Domain',
+	'Unlicense',
+	'WTFPL',
+];

--- a/packages/licenses/ossLicenses.js
+++ b/packages/licenses/ossLicenses.js
@@ -1,0 +1,3 @@
+module.exports = [
+	'Apache-2.0',
+];

--- a/packages/licenses/package.json
+++ b/packages/licenses/package.json
@@ -1,0 +1,34 @@
+{
+	"name": "@wordpress/licenses",
+	"version": "0.1.0",
+	"description": "WordPress Licenses",
+	"author": "WordPress",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"gpl",
+		"gpl2",
+		"license",
+		"licenses",
+		"oss",
+		"spdx"
+	],
+	"homepage": "https://github.com/WordPress/packages/tree/master/packages/licenses/README.md",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/WordPress/packages.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/packages/issues"
+	},
+	"files": [
+		"gpl2Licenses",
+		"OSSLicenses"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"test": "echo \"Error: run tests from root\" && exit 1"
+	}
+}

--- a/packages/licenses/test/index.test.js
+++ b/packages/licenses/test/index.test.js
@@ -1,0 +1,10 @@
+const configGpl2Licenses = require( '../gpl2Licenses' );
+const configOssLicenses = require( '../ossLicenses' );
+
+it( 'should export an array', () => {
+	expect( Array.isArray( configGpl2Licenses ) ).toBe( true );
+});
+
+it( 'should export an array', () => {
+	expect( Array.isArray( configOssLicenses ) ).toBe( true );
+});


### PR DESCRIPTION
Initial `@wordpress/licenses` package for use in #129 & #130